### PR TITLE
Add getDefaultStorageClassName function in virtualmachine_controller

### DIFF
--- a/pkg/controller/virtualization/virtualmachine/virtualmachine_controller.go
+++ b/pkg/controller/virtualization/virtualmachine/virtualmachine_controller.go
@@ -41,6 +41,7 @@ const (
 	messageResourceSynced                 = "VirtualMachine synced successfully"
 	pvcCreateByDiskVolumeTemplatePrefix   = "tpl-" // tpl: template
 	pvcCreateByDiskVolumeControllerPrefix = "new-"
+	volumeSnapshotClassName               = "cstor-csi-disk"
 )
 
 // Reconciler reconciles a cnat object
@@ -88,8 +89,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
-	if defaultStorageClassName == "cstor-csi-disk" {
-		volumeSnapshotClassName := defaultStorageClassName
+	if defaultStorageClassName == volumeSnapshotClassName {
 		vsc := snapv1.VolumeSnapshotClass{}
 		if err := r.Get(rootCtx, client.ObjectKey{Name: volumeSnapshotClassName}, &vsc); err != nil {
 			if errors.IsNotFound(err) {


### PR DESCRIPTION
Add getDefaultStorageClassName function in virtualmachine_controller.go to enable creating virtual machines via the ecpaas website when the default StorageClass is openebs-hostpath in ecpaas.