### PR TITLE
Set MinIO bucket policy after the bucket is created.

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -47,7 +47,6 @@ import (
 	runtimecache "sigs.k8s.io/controller-runtime/pkg/cache"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/minio/minio-go/v7"
 	audit "kubesphere.io/kubesphere/pkg/apiserver/auditing"
 	"kubesphere.io/kubesphere/pkg/apiserver/authentication/authenticators/basic"
 	"kubesphere.io/kubesphere/pkg/apiserver/authentication/authenticators/jwt"
@@ -173,7 +172,7 @@ type APIServer struct {
 
 	OpenpitrixClient openpitrix.Interface
 
-	MinioClient *minio.Client
+	MinioClient *volumev1alpha1.MinioClient
 
 	KubevirtClient kubecli.KubevirtClient
 }

--- a/pkg/kapis/virtualization/v1/handler.go
+++ b/pkg/kapis/virtualization/v1/handler.go
@@ -24,6 +24,7 @@ import (
 	kubesphere "kubesphere.io/kubesphere/pkg/client/clientset/versioned"
 
 	virtzv1alpha1 "kubesphere.io/api/virtualization/v1alpha1"
+	volume "kubesphere.io/kubesphere/pkg/kapis/volume/v1alpha1"
 	ui_virtz "kubesphere.io/kubesphere/pkg/models/virtualization"
 )
 
@@ -38,11 +39,11 @@ type BadRequestError struct {
 	Reason string `json:"reason"`
 }
 
-func newHandler(ksclient kubesphere.Interface, k8sclient kubernetes.Interface, factory informers.InformerFactory, minioClient *minio.Client, virtClient kubecli.KubevirtClient) virtzhandler {
+func newHandler(ksclient kubesphere.Interface, k8sclient kubernetes.Interface, factory informers.InformerFactory, minioClient *volume.MinioClient, virtClient kubecli.KubevirtClient) virtzhandler {
 	return virtzhandler{
 		virtz:               ui_virtz.New(ksclient, k8sclient),
 		resourceQuotaGetter: quotas.NewResourceQuotaGetter(factory.KubernetesSharedInformerFactory(), factory.KubeSphereSharedInformerFactory()),
-		minioClient:         minioClient,
+		minioClient:         minioClient.MinioClient,
 		kubevirtClient:      virtClient,
 	}
 }

--- a/pkg/kapis/virtualization/v1/register.go
+++ b/pkg/kapis/virtualization/v1/register.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/emicklei/go-restful"
 	restfulspec "github.com/emicklei/go-restful-openapi"
-	"github.com/minio/minio-go/v7"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"kubevirt.io/client-go/kubecli"
@@ -21,6 +20,7 @@ import (
 	"kubesphere.io/kubesphere/pkg/apiserver/runtime"
 	"kubesphere.io/kubesphere/pkg/constants"
 	"kubesphere.io/kubesphere/pkg/informers"
+	volume "kubesphere.io/kubesphere/pkg/kapis/volume/v1alpha1"
 	ui_virtz "kubesphere.io/kubesphere/pkg/models/virtualization"
 )
 
@@ -38,7 +38,7 @@ var imagePostCloneNotes = `Source image's namespace shall be different from new 
 
 var GroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1"}
 
-func AddToContainer(container *restful.Container, minioClient *minio.Client, kubevirtClient kubecli.KubevirtClient, ksclient kubesphere.Interface, k8sclient kubernetes.Interface, factory informers.InformerFactory) error {
+func AddToContainer(container *restful.Container, minioClient *volume.MinioClient, kubevirtClient kubecli.KubevirtClient, ksclient kubesphere.Interface, k8sclient kubernetes.Interface, factory informers.InformerFactory) error {
 	webservice := runtime.NewWebService(GroupVersion)
 	handler := newHandler(ksclient, k8sclient, factory, minioClient, kubevirtClient)
 

--- a/pkg/kapis/volume/v1alpha1/register.go
+++ b/pkg/kapis/volume/v1alpha1/register.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/emicklei/go-restful"
 	restfulspec "github.com/emicklei/go-restful-openapi"
-	"github.com/minio/minio-go/v7"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"kubesphere.io/kubesphere/pkg/api"
@@ -29,7 +28,7 @@ func Resource(resource string) schema.GroupResource {
 	return GroupVersion.WithResource(resource).GroupResource()
 }
 
-func AddToContainer(container *restful.Container, minioClient *minio.Client, k8sclient kubernetes.Interface, ksclient kubesphere.Interface) error {
+func AddToContainer(container *restful.Container, minioClient *MinioClient, k8sclient kubernetes.Interface, ksclient kubesphere.Interface) error {
 	webservice := runtime.NewWebService(GroupVersion)
 	handler := newHandler(minioClient, k8sclient, ksclient)
 

--- a/pkg/kapis/volume/v1alpha1/type.go
+++ b/pkg/kapis/volume/v1alpha1/type.go
@@ -1,0 +1,14 @@
+/*
+Copyright(c) 2024-present Accton. All rights reserved. www.accton.com.tw
+*/
+
+package v1
+
+import "github.com/minio/minio-go/v7"
+
+type MinioClient struct {
+	MinioClient *minio.Client
+	EndpointURL string
+	Username    string
+	Password    string
+}

--- a/pkg/simple/client/minio/minio.go
+++ b/pkg/simple/client/minio/minio.go
@@ -8,9 +8,10 @@ import (
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"k8s.io/klog"
+	volume "kubesphere.io/kubesphere/pkg/kapis/volume/v1alpha1"
 )
 
-func NewMinioClient(options *Options) (*minio.Client, error) {
+func NewMinioClient(options *Options) (*volume.MinioClient, error) {
 
 	useSSL := false
 
@@ -21,6 +22,12 @@ func NewMinioClient(options *Options) (*minio.Client, error) {
 	if err != nil {
 		klog.Fatalf("unable to create MinioClient: %v", err)
 	}
+	client := volume.MinioClient{
+		MinioClient: minioClient,
+		EndpointURL: options.Endpoint,
+		Username:    options.AccessKeyID,
+		Password:    options.SecretAccessKey,
+	}
 
-	return minioClient, err
+	return &client, err
 }

--- a/tools/cmd/accton-doc-gen/main.go
+++ b/tools/cmd/accton-doc-gen/main.go
@@ -78,10 +78,11 @@ func generateSwaggerJson() []byte {
 
 	container := runtime.Container
 	informerFactory := informers.NewNullInformerFactory()
+	minioClient := volumev1alpha1.MinioClient{}
 
 	urlruntime.Must(vpcv1.AddToContainer(container, informerFactory, nil, nil))
 	urlruntime.Must(volumev1alpha1.AddToContainer(container, nil, nil, nil))
-	urlruntime.Must(virtualizationv1.AddToContainer(container, nil, nil, nil, nil, informerFactory))
+	urlruntime.Must(virtualizationv1.AddToContainer(container, &minioClient, nil, nil, nil, informerFactory))
 
 	config := restfulspec.Config{
 		WebServices:                   container.RegisteredWebServices(),


### PR DESCRIPTION
The default bucket policy is set to readonly, therefore it is better to change the bucket policy to readwrite. 
If the bucket policy is readonly the virtual machine's image will not upload successfully.

Note: MinIO Go Client API "SetBucketPolicy" is not working for changing the policy.