### PR TITLE
Feat: Add image status explanative state

### DIFF
--- a/api/ac-openapi-spec/swagger.json
+++ b/api/ac-openapi-spec/swagger.json
@@ -2377,12 +2377,17 @@
     },
     "virtualization.ImageStatus": {
       "required": [
-        "ready"
+        "ready",
+        "state"
       ],
       "properties": {
         "ready": {
           "description": "Image is ready or not",
           "type": "boolean"
+        },
+        "state": {
+          "description": "Image operation state",
+          "type": "string"
         }
       }
     },

--- a/pkg/models/virtualization/types.go
+++ b/pkg/models/virtualization/types.go
@@ -182,7 +182,8 @@ type ImageResponse struct {
 }
 
 type ImageStatus struct {
-	Ready bool `json:"ready" description:"Image is ready or not"`
+	Ready bool   `json:"ready" description:"Image is ready or not"`
+	State string `json:"state" description:"Image operation state"`
 }
 
 type ListImageResponse struct {


### PR DESCRIPTION
Add explanative state in image status of below APIs
- GET /kapis/virtualization.ecpaas.io/v1/images
- GET /kapis/virtualization.ecpaas.io/v1/namespaces/{namespace}/images
- GET /kapis/virtualization.ecpaas.io/v1/namespaces/{namespace}/images/{id}