### PR TITLE
Feat: Add label and node selector to virtual machine

### DIFF
--- a/api/ac-openapi-spec/swagger.json
+++ b/api/ac-openapi-spec/swagger.json
@@ -805,7 +805,7 @@
           "403": {
             "description": "Invalid format",
             "schema": {
-              "$ref": "#/definitions/virtualization.BadRequestError"
+              "$ref": "#/definitions/util.BadRequestError"
             }
           },
           "500": {
@@ -896,7 +896,7 @@
           "403": {
             "description": "Invalid format",
             "schema": {
-              "$ref": "#/definitions/virtualization.BadRequestError"
+              "$ref": "#/definitions/util.BadRequestError"
             }
           },
           "404": {
@@ -1012,7 +1012,7 @@
           "403": {
             "description": "Invalid format",
             "schema": {
-              "$ref": "#/definitions/virtualization.BadRequestError"
+              "$ref": "#/definitions/util.BadRequestError"
             }
           },
           "500": {
@@ -1059,7 +1059,7 @@
           "403": {
             "description": "Invalid format",
             "schema": {
-              "$ref": "#/definitions/virtualization.BadRequestError"
+              "$ref": "#/definitions/util.BadRequestError"
             }
           },
           "500": {
@@ -1150,7 +1150,7 @@
           "403": {
             "description": "Invalid format",
             "schema": {
-              "$ref": "#/definitions/virtualization.BadRequestError"
+              "$ref": "#/definitions/util.BadRequestError"
             }
           },
           "404": {
@@ -1266,7 +1266,7 @@
           "403": {
             "description": "Invalid format",
             "schema": {
-              "$ref": "#/definitions/virtualization.BadRequestError"
+              "$ref": "#/definitions/util.BadRequestError"
             }
           },
           "500": {
@@ -1357,7 +1357,7 @@
           "403": {
             "description": "Invalid format",
             "schema": {
-              "$ref": "#/definitions/virtualization.BadRequestError"
+              "$ref": "#/definitions/util.BadRequestError"
             }
           },
           "500": {
@@ -2047,6 +2047,16 @@
         }
       }
     },
+    "util.BadRequestError": {
+      "required": [
+        "reason"
+      ],
+      "properties": {
+        "reason": {
+          "type": "string"
+        }
+      }
+    },
     "v1.ClusterRouterPolicy": {
       "required": [
         "destination",
@@ -2461,16 +2471,6 @@
           "type": "string"
         },
         "vpc": {
-          "type": "string"
-        }
-      }
-    },
-    "virtualization.BadRequestError": {
-      "required": [
-        "reason"
-      ],
-      "properties": {
-        "reason": {
           "type": "string"
         }
       }

--- a/api/ac-openapi-spec/swagger.json
+++ b/api/ac-openapi-spec/swagger.json
@@ -3032,6 +3032,13 @@
             "$ref": "#/definitions/virtualization.ModifyDiskSpec"
           }
         },
+        "labels": {
+          "description": "Virtual machine labels. Can be empty map.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "memory": {
           "description": "Virtual machine memory size, unit is GB.",
           "type": "integer",
@@ -3044,6 +3051,13 @@
           "description": "Virtual machine name. Valid characters: A-Z, a-z, 0-9, and -(hyphen).",
           "type": "string",
           "maximum": 16
+        },
+        "node_selector": {
+          "description": "Virtual machine node selector.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       }
     },
@@ -3111,6 +3125,13 @@
           "description": "Virtual machine image source",
           "$ref": "#/definitions/virtualization.ImageInfoResponse"
         },
+        "labels": {
+          "description": "Virtual machine labels",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "memory": {
           "description": "Virtual machine memory size, unit is GB",
           "type": "integer",
@@ -3123,6 +3144,13 @@
           "description": "Virtual machine name. Valid characters: A-Z, a-z, 0-9, and -(hyphen).",
           "type": "string",
           "maximum": 16
+        },
+        "node_selector": {
+          "description": "Virtual machine node selector",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       }
     },
@@ -3138,7 +3166,9 @@
         "disks",
         "status",
         "node_name",
-        "pod_name"
+        "pod_name",
+        "labels",
+        "node_selector"
       ],
       "properties": {
         "cpu_cores": {
@@ -3165,6 +3195,13 @@
           "description": "Virtual machine image source",
           "$ref": "#/definitions/virtualization.ImageInfoResponse"
         },
+        "labels": {
+          "description": "Virtual machine labels",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "memory": {
           "description": "Virtual machine memory size",
           "type": "integer",
@@ -3181,6 +3218,13 @@
         "node_name": {
           "description": "Virtual machine node",
           "type": "string"
+        },
+        "node_selector": {
+          "description": "Virtual machine node selector",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "pod_name": {
           "description": "Virtual machine pod",

--- a/api/ac-openapi-spec/swagger.json
+++ b/api/ac-openapi-spec/swagger.json
@@ -1833,13 +1833,13 @@
     "metering.PriceResponse": {
       "required": [
         "retention_day",
+        "gpu_per_percentage_per_hour",
+        "currency",
         "cpu_per_core_per_hour",
         "mem_per_gigabytes_per_hour",
         "ingress_network_traffic_per_megabytes_per_hour",
         "egress_network_traffic_per_megabytes_per_hour",
-        "pvc_per_gigabytes_per_hour",
-        "gpu_per_percentage_per_hour",
-        "currency"
+        "pvc_per_gigabytes_per_hour"
       ],
       "properties": {
         "cpu_per_core_per_hour": {
@@ -2865,6 +2865,25 @@
         }
       }
     },
+    "virtualization.Label": {
+      "required": [
+        "key",
+        "value"
+      ],
+      "properties": {
+        "key": {
+          "description": "Label key(unique key). Valid characters: A-Z, a-z, 0-9, -(hyphen), _(underscore), .(dot), and /(slash).",
+          "type": "string",
+          "maximum": 316,
+          "minimum": 1
+        },
+        "value": {
+          "description": "Label value. Valid characters: A-Z, a-z, 0-9, -(hyphen), _(underscore), and .(dot). Can be empty string.",
+          "type": "string",
+          "maximum": 63
+        }
+      }
+    },
     "virtualization.ListDiskResponse": {
       "required": [
         "total_count",
@@ -3033,10 +3052,10 @@
           }
         },
         "labels": {
-          "description": "Virtual machine labels. Can be empty map.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
+          "description": "Virtual machine labels. Can be empty array.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/virtualization.Label"
           }
         },
         "memory": {
@@ -3053,11 +3072,30 @@
           "maximum": 16
         },
         "node_selector": {
-          "description": "Virtual machine node selector.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
+          "description": "Virtual machine node selector. Can be empty array.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/virtualization.NodeSelector"
           }
+        }
+      }
+    },
+    "virtualization.NodeSelector": {
+      "required": [
+        "key",
+        "value"
+      ],
+      "properties": {
+        "key": {
+          "description": "NodeSelector key(unique key). Valid characters: A-Z, a-z, 0-9, -(hyphen), _(underscore), .(dot), and /(slash).",
+          "type": "string",
+          "maximum": 316,
+          "minimum": 1
+        },
+        "value": {
+          "description": "NodeSelector value. Valid characters: A-Z, a-z, 0-9, -(hyphen), _(underscore), and .(dot). Can be empty string.",
+          "type": "string",
+          "maximum": 63
         }
       }
     },
@@ -3127,9 +3165,9 @@
         },
         "labels": {
           "description": "Virtual machine labels",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/virtualization.Label"
           }
         },
         "memory": {
@@ -3147,9 +3185,9 @@
         },
         "node_selector": {
           "description": "Virtual machine node selector",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/virtualization.NodeSelector"
           }
         }
       }
@@ -3197,9 +3235,9 @@
         },
         "labels": {
           "description": "Virtual machine labels",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/virtualization.Label"
           }
         },
         "memory": {
@@ -3221,9 +3259,9 @@
         },
         "node_selector": {
           "description": "Virtual machine node selector",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/virtualization.NodeSelector"
           }
         },
         "pod_name": {

--- a/api/ac-openapi-spec/swagger.json
+++ b/api/ac-openapi-spec/swagger.json
@@ -1833,13 +1833,13 @@
     "metering.PriceResponse": {
       "required": [
         "retention_day",
-        "gpu_per_percentage_per_hour",
-        "currency",
         "cpu_per_core_per_hour",
         "mem_per_gigabytes_per_hour",
         "ingress_network_traffic_per_megabytes_per_hour",
         "egress_network_traffic_per_megabytes_per_hour",
-        "pvc_per_gigabytes_per_hour"
+        "pvc_per_gigabytes_per_hour",
+        "gpu_per_percentage_per_hour",
+        "currency"
       ],
       "properties": {
         "cpu_per_core_per_hour": {

--- a/config/crds/virtualization.ecpaas.io_virtualmachines.yaml
+++ b/config/crds/virtualization.ecpaas.io_virtualmachines.yaml
@@ -1257,6 +1257,13 @@ spec:
                       type: object
                     type: array
                 type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector is a selector which must be true for the
+                  VirtualMachine to fit on a node. Selector which must match a node's
+                  labels for the VirtualMachine to be scheduled on that node.
+                type: object
               runStrategy:
                 description: RunStrategy is the run strategy of the VirtualMachine.
                 type: string

--- a/pkg/kapis/util/validation.go
+++ b/pkg/kapis/util/validation.go
@@ -1,0 +1,91 @@
+/*
+Copyright(c) 2024-present Accton. All rights reserved. www.accton.com
+*/
+
+package util
+
+import (
+	"net/http"
+	"reflect"
+	"regexp"
+	"strconv"
+
+	"github.com/emicklei/go-restful"
+)
+
+type BadRequestError struct {
+	Reason string `json:"reason"`
+}
+
+func IsValidLength(validateType reflect.Type, valueToValidate string, fieldName string, resp *restful.Response) bool {
+	field, found := validateType.FieldByName(fieldName)
+	if found {
+		maximum, _ := strconv.Atoi(field.Tag.Get("maximum"))
+		if len(valueToValidate) > int(maximum) {
+			resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
+				Reason: fieldName + " length should be less than " + field.Tag.Get("maximum"),
+			})
+			return false
+		}
+	}
+	return true
+}
+
+// Check if all label pairs are valid. If quantity of labels is reduced after being converted to map, there are duplicated keys.
+func IsValidLabels(validateType reflect.Type, size int, labels map[string]string, resp *restful.Response) bool {
+	if size > len(labels) {
+		resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
+			Reason: validateType.Name() + " Key should be unique",
+		})
+		return false
+	} else {
+		for key, value := range labels { // Empty array is also valid.
+			if !IsValidLabelEntry(validateType, key, value, resp) { // check validness
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func IsValidLabelEntry(validateType reflect.Type, key string, value string, resp *restful.Response) bool {
+	if !IsValidLength(validateType, key, "Key", resp) {
+		return false
+	}
+
+	if !IsValidLabelKeyString(key, resp) {
+		return false
+	}
+
+	if !IsValidLength(validateType, value, "Value", resp) {
+		return false
+	}
+
+	if !IsValidLabelValueString(value, resp) {
+		return false
+	}
+
+	return true
+}
+
+func IsValidLabelKeyString(valueToValidate string, resp *restful.Response) bool {
+	validRegex := regexp.MustCompile("^[A-Za-z0-9-_./]+$")
+	if !validRegex.MatchString(valueToValidate) {
+		resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
+			Reason: "Invalid key. Valid characters: A-Z, a-z, 0-9, -(hyphen), _(underscore), .(dot), and /(slash)",
+		})
+		return false
+	}
+	return true
+}
+
+func IsValidLabelValueString(valueToValidate string, resp *restful.Response) bool {
+	validRegex := regexp.MustCompile("^[A-Za-z0-9-_.]*$") // Also match "", so use '*'
+	if !validRegex.MatchString(valueToValidate) {
+		resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
+			Reason: "Invalid value. Valid characters: A-Z, a-z, 0-9, -(hyphen), _(underscore), and .(dot)",
+		})
+		return false
+	}
+	return true
+}

--- a/pkg/kapis/virtualization/v1/handler.go
+++ b/pkg/kapis/virtualization/v1/handler.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -21,6 +22,7 @@ import (
 	"k8s.io/klog"
 	"kubesphere.io/kubesphere/pkg/api"
 	"kubesphere.io/kubesphere/pkg/informers"
+	"kubesphere.io/kubesphere/pkg/kapis/util"
 	"kubesphere.io/kubesphere/pkg/models/quotas"
 	"kubevirt.io/client-go/kubecli"
 
@@ -36,10 +38,6 @@ type virtzhandler struct {
 	minioClient         *minio.Client
 	k8sClient           kubernetes.Interface
 	kubevirtClient      kubecli.KubevirtClient
-}
-
-type BadRequestError struct {
-	Reason string `json:"reason"`
 }
 
 func newHandler(ksclient kubesphere.Interface, k8sclient kubernetes.Interface, factory informers.InformerFactory, minioClient *minio.Client, virtClient kubecli.KubevirtClient) virtzhandler {
@@ -70,11 +68,13 @@ func (h *virtzhandler) CreateVirtualMahcine(req *restful.Request, resp *restful.
 		return
 	}
 
-	if !isValidLabelDuplicated(ui_vm.Labels, resp) {
+	validateType := reflect.TypeOf(ui_vm.Labels).Elem()
+	if !util.IsValidLabels(validateType, len(ui_vm.Labels), ui_virtz.ConvertLabelToMap(ui_vm.Labels), resp) {
 		return
 	}
 
-	if !isValidNodeSelectorDuplicated(ui_vm.NodeSelector, resp) {
+	validateType = reflect.TypeOf(ui_vm.NodeSelector).Elem()
+	if !util.IsValidLabels(validateType, len(ui_vm.NodeSelector), ui_virtz.ConvertLabelToMap(ui_vm.NodeSelector), resp) {
 		return
 	}
 
@@ -109,11 +109,13 @@ func (h *virtzhandler) UpdateVirtualMahcine(req *restful.Request, resp *restful.
 		return
 	}
 
-	if !isValidLabelDuplicated(ui_vm.Labels, resp) {
+	validateType := reflect.TypeOf(ui_vm.Labels).Elem()
+	if !util.IsValidLabels(validateType, len(ui_vm.Labels), ui_virtz.ConvertLabelToMap(ui_vm.Labels), resp) {
 		return
 	}
 
-	if !isValidNodeSelectorDuplicated(ui_vm.NodeSelector, resp) {
+	validateType = reflect.TypeOf(ui_vm.NodeSelector).Elem()
+	if !util.IsValidLabels(validateType, len(ui_vm.NodeSelector), ui_virtz.ConvertLabelToMap(ui_vm.NodeSelector), resp) {
 		return
 	}
 

--- a/pkg/kapis/virtualization/v1/handler.go
+++ b/pkg/kapis/virtualization/v1/handler.go
@@ -201,8 +201,8 @@ func (h *virtzhandler) getUIVirtualMachineResponse(vm *virtzv1alpha1.VirtualMach
 		Status:       ui_vm_status,
 		NodeName:     h.getVirtualMachineNode(vm.Namespace, vm.Name),
 		PodName:      h.getVirtualMachinePod(vm.Namespace, vm.Name),
-		Labels:       getVirtualMachineLabels(&vm.Labels),
-		NodeSelector: vm.Annotations[virtzv1alpha1.VirtualizationNodeSelector],
+		Labels:       getMapOrEmptyMap(&vm.Labels),
+		NodeSelector: getMapOrEmptyMap(&vm.Spec.NodeSelector),
 	}
 }
 
@@ -238,9 +238,9 @@ func (h *virtzhandler) getVirtualMachinePod(namespace, vmName string) string {
 	return "Not Established"
 }
 
-func getVirtualMachineLabels(labels *map[string]string) map[string]string {
-	if *labels != nil {
-		return *labels
+func getMapOrEmptyMap(incomingMap *map[string]string) map[string]string {
+	if *incomingMap != nil {
+		return *incomingMap
 	} else {
 		return make(map[string]string)
 	}

--- a/pkg/kapis/virtualization/v1/handler.go
+++ b/pkg/kapis/virtualization/v1/handler.go
@@ -190,18 +190,19 @@ func (h *virtzhandler) getUIVirtualMachineResponse(vm *virtzv1alpha1.VirtualMach
 
 	memory, _ := strconv.ParseUint(strings.Replace(vm.Spec.Hardware.Domain.Resources.Requests.Memory().String(), "Gi", "", -1), 10, 32)
 	return ui_virtz.VirtualMachineResponse{
-		Name:        vm.Annotations[virtzv1alpha1.VirtualizationAliasName],
-		ID:          vm.Name,
-		Namespace:   vm.Namespace,
-		Description: vm.Annotations[virtzv1alpha1.VirtualizationDescription],
-		CpuCores:    uint(vm.Spec.Hardware.Domain.CPU.Cores),
-		Memory:      uint(memory),
-		Image:       &ui_image_spec,
-		Disks:       h.getUIDisksResponse(vm),
-		Status:      ui_vm_status,
-		NodeName:    h.getVirtualMachineNode(vm.Namespace, vm.Name),
-		PodName:     h.getVirtualMachinePod(vm.Namespace, vm.Name),
-		Labels:      getVirtualMachineLabels(&vm.Labels),
+		Name:         vm.Annotations[virtzv1alpha1.VirtualizationAliasName],
+		ID:           vm.Name,
+		Namespace:    vm.Namespace,
+		Description:  vm.Annotations[virtzv1alpha1.VirtualizationDescription],
+		CpuCores:     uint(vm.Spec.Hardware.Domain.CPU.Cores),
+		Memory:       uint(memory),
+		Image:        &ui_image_spec,
+		Disks:        h.getUIDisksResponse(vm),
+		Status:       ui_vm_status,
+		NodeName:     h.getVirtualMachineNode(vm.Namespace, vm.Name),
+		PodName:      h.getVirtualMachinePod(vm.Namespace, vm.Name),
+		Labels:       getVirtualMachineLabels(&vm.Labels),
+		NodeSelector: vm.Annotations[virtzv1alpha1.VirtualizationNodeSelector],
 	}
 }
 

--- a/pkg/kapis/virtualization/v1/handler.go
+++ b/pkg/kapis/virtualization/v1/handler.go
@@ -201,6 +201,7 @@ func (h *virtzhandler) getUIVirtualMachineResponse(vm *virtzv1alpha1.VirtualMach
 		Status:      ui_vm_status,
 		NodeName:    h.getVirtualMachineNode(vm.Namespace, vm.Name),
 		PodName:     h.getVirtualMachinePod(vm.Namespace, vm.Name),
+		Labels:      getVirtualMachineLabels(&vm.Labels),
 	}
 }
 
@@ -234,6 +235,14 @@ func (h *virtzhandler) getVirtualMachinePod(namespace, vmName string) string {
 		}
 	}
 	return "Not Established"
+}
+
+func getVirtualMachineLabels(labels *map[string]string) map[string]string {
+	if *labels != nil {
+		return *labels
+	} else {
+		return make(map[string]string)
+	}
 }
 
 func (h *virtzhandler) getUIImageInfoResponse(vm *virtzv1alpha1.VirtualMachine) ui_virtz.ImageInfoResponse {

--- a/pkg/kapis/virtualization/v1/register.go
+++ b/pkg/kapis/virtualization/v1/register.go
@@ -21,6 +21,7 @@ import (
 	"kubesphere.io/kubesphere/pkg/apiserver/runtime"
 	"kubesphere.io/kubesphere/pkg/constants"
 	"kubesphere.io/kubesphere/pkg/informers"
+	"kubesphere.io/kubesphere/pkg/kapis/util"
 	ui_virtz "kubesphere.io/kubesphere/pkg/models/virtualization"
 )
 
@@ -51,7 +52,7 @@ func AddToContainer(container *restful.Container, minioClient *minio.Client, kub
 		Reads(ui_virtz.VirtualMachineRequest{}).
 		Doc("Create virtual machine").
 		Returns(http.StatusOK, api.StatusOK, ui_virtz.VirtualMachineIDResponse{}).
-		Returns(http.StatusForbidden, "Invalid format", BadRequestError{}).
+		Returns(http.StatusForbidden, "Invalid format", util.BadRequestError{}).
 		Returns(http.StatusInternalServerError, api.StatusInternalServerError, nil).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.VirtualMachineTag}))
 
@@ -63,7 +64,7 @@ func AddToContainer(container *restful.Container, minioClient *minio.Client, kub
 		Doc("Update virtual machine").
 		Notes(vmPutNotes).
 		Returns(http.StatusOK, api.StatusOK, nil).
-		Returns(http.StatusForbidden, "Invalid format", BadRequestError{}).
+		Returns(http.StatusForbidden, "Invalid format", util.BadRequestError{}).
 		Returns(http.StatusInternalServerError, api.StatusInternalServerError, nil).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.VirtualMachineTag}))
 
@@ -126,7 +127,7 @@ func AddToContainer(container *restful.Container, minioClient *minio.Client, kub
 		Reads(ui_virtz.DiskRequest{}).
 		Doc("Create disk").
 		Returns(http.StatusOK, api.StatusOK, ui_virtz.DiskIDResponse{}).
-		Returns(http.StatusForbidden, "Invalid format", BadRequestError{}).
+		Returns(http.StatusForbidden, "Invalid format", util.BadRequestError{}).
 		Returns(http.StatusInternalServerError, api.StatusInternalServerError, nil).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DiskTag}))
 
@@ -138,7 +139,7 @@ func AddToContainer(container *restful.Container, minioClient *minio.Client, kub
 		Doc("Update disk").
 		Notes(diskPutNotes).
 		Returns(http.StatusOK, api.StatusOK, nil).
-		Returns(http.StatusForbidden, "Invalid format", BadRequestError{}).
+		Returns(http.StatusForbidden, "Invalid format", util.BadRequestError{}).
 		Returns(http.StatusNotFound, api.StatusNotFound, nil).
 		Returns(http.StatusInternalServerError, api.StatusInternalServerError, nil).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DiskTag}))
@@ -184,7 +185,7 @@ func AddToContainer(container *restful.Container, minioClient *minio.Client, kub
 		Reads(ui_virtz.ImageRequest{}).
 		Doc("Create image").
 		Returns(http.StatusOK, api.StatusOK, ui_virtz.ImageIDResponse{}).
-		Returns(http.StatusForbidden, "Invalid format", BadRequestError{}).
+		Returns(http.StatusForbidden, "Invalid format", util.BadRequestError{}).
 		Returns(http.StatusInternalServerError, api.StatusInternalServerError, nil).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.ImageTag}))
 
@@ -195,7 +196,7 @@ func AddToContainer(container *restful.Container, minioClient *minio.Client, kub
 		Doc("Clone image").
 		Notes(imagePostCloneNotes).
 		Returns(http.StatusOK, api.StatusOK, ui_virtz.ImageIDResponse{}).
-		Returns(http.StatusForbidden, "Invalid format", BadRequestError{}).
+		Returns(http.StatusForbidden, "Invalid format", util.BadRequestError{}).
 		Returns(http.StatusInternalServerError, api.StatusInternalServerError, nil).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.ImageTag}))
 
@@ -207,7 +208,7 @@ func AddToContainer(container *restful.Container, minioClient *minio.Client, kub
 		Doc("Update image").
 		Notes(imagePutNotes).
 		Returns(http.StatusOK, api.StatusOK, nil).
-		Returns(http.StatusForbidden, "Invalid format", BadRequestError{}).
+		Returns(http.StatusForbidden, "Invalid format", util.BadRequestError{}).
 		Returns(http.StatusNotFound, api.StatusNotFound, nil).
 		Returns(http.StatusInternalServerError, api.StatusInternalServerError, nil).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.ImageTag}))

--- a/pkg/kapis/virtualization/v1/validation.go
+++ b/pkg/kapis/virtualization/v1/validation.go
@@ -16,6 +16,7 @@ import (
 	"github.com/minio/minio-go/v7"
 	virtzv1alpha1 "kubesphere.io/api/virtualization/v1alpha1"
 
+	"kubesphere.io/kubesphere/pkg/kapis/util"
 	ui_virtz "kubesphere.io/kubesphere/pkg/models/virtualization"
 )
 
@@ -23,7 +24,7 @@ var bucketName = "ecpaas-images"
 
 func isValidModifyDisk(validateType reflect.Type, disk ui_virtz.ModifyDiskSpec, resp *restful.Response) bool {
 	if disk.Action != "mount" && disk.Action != "unmount" {
-		resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
+		resp.WriteHeaderAndEntity(http.StatusForbidden, util.BadRequestError{
 			Reason: "Disk action should be 'mount' or 'unmount'",
 		})
 		return false
@@ -38,7 +39,7 @@ func isValidWithinRange(validateType reflect.Type, valueToValidate int, fieldNam
 		minimum, _ := strconv.Atoi(field.Tag.Get("minimum"))
 		maximum, _ := strconv.Atoi(field.Tag.Get("maximum"))
 		if valueToValidate > maximum || valueToValidate < minimum {
-			resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
+			resp.WriteHeaderAndEntity(http.StatusForbidden, util.BadRequestError{
 				Reason: fieldName + " should be in the range of " + field.Tag.Get("minimum") + " to " + field.Tag.Get("maximum"),
 			})
 			return false
@@ -48,24 +49,10 @@ func isValidWithinRange(validateType reflect.Type, valueToValidate int, fieldNam
 
 }
 
-func isValidLength(validateType reflect.Type, valueToValidate string, fieldName string, resp *restful.Response) bool {
-	field, found := validateType.FieldByName(fieldName)
-	if found {
-		maximum, _ := strconv.Atoi(field.Tag.Get("maximum"))
-		if len(valueToValidate) > int(maximum) {
-			resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
-				Reason: fieldName + " length should be less than " + field.Tag.Get("maximum"),
-			})
-			return false
-		}
-	}
-	return true
-}
-
 func isValidString(valueToValidate string, resp *restful.Response) bool {
 	validRegex := regexp.MustCompile("^[A-Za-z0-9-]+$")
 	if !validRegex.MatchString(valueToValidate) {
-		resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
+		resp.WriteHeaderAndEntity(http.StatusForbidden, util.BadRequestError{
 			Reason: "Valid characters: A-Z, a-z, 0-9, and -(hyphen)",
 		})
 		return false
@@ -76,7 +63,7 @@ func isValidString(valueToValidate string, resp *restful.Response) bool {
 func isValidVirtualMachine(vm ui_virtz.VirtualMachineRequest, resp *restful.Response) bool {
 
 	reflectType := reflect.TypeOf(vm)
-	if !isValidLength(reflectType, vm.Name, "Name", resp) {
+	if !util.IsValidLength(reflectType, vm.Name, "Name", resp) {
 		return false
 	}
 
@@ -84,7 +71,7 @@ func isValidVirtualMachine(vm ui_virtz.VirtualMachineRequest, resp *restful.Resp
 		return false
 	}
 
-	if !isValidLength(reflectType, vm.Description, "Description", resp) {
+	if !util.IsValidLength(reflectType, vm.Description, "Description", resp) {
 		return false
 	}
 
@@ -102,7 +89,7 @@ func isValidVirtualMachine(vm ui_virtz.VirtualMachineRequest, resp *restful.Resp
 func isValidModifyVirtualMachine(vm ui_virtz.ModifyVirtualMachineRequest, resp *restful.Response) bool {
 
 	reflectType := reflect.TypeOf(vm)
-	if !isValidLength(reflectType, vm.Name, "Name", resp) {
+	if !util.IsValidLength(reflectType, vm.Name, "Name", resp) {
 		return false
 	}
 
@@ -113,7 +100,7 @@ func isValidModifyVirtualMachine(vm ui_virtz.ModifyVirtualMachineRequest, resp *
 	}
 
 	if vm.Description != nil {
-		if !isValidLength(reflectType, *vm.Description, "Description", resp) {
+		if !util.IsValidLength(reflectType, *vm.Description, "Description", resp) {
 			return false
 		}
 	}
@@ -144,7 +131,7 @@ func isValidModifyVirtualMachine(vm ui_virtz.ModifyVirtualMachineRequest, resp *
 func isValidDiskRequest(disk ui_virtz.DiskRequest, resp *restful.Response) bool {
 
 	reflectType := reflect.TypeOf(disk)
-	if !isValidLength(reflectType, disk.Name, "Name", resp) {
+	if !util.IsValidLength(reflectType, disk.Name, "Name", resp) {
 		return false
 	}
 
@@ -152,7 +139,7 @@ func isValidDiskRequest(disk ui_virtz.DiskRequest, resp *restful.Response) bool 
 		return false
 	}
 
-	if !isValidLength(reflectType, disk.Description, "Description", resp) {
+	if !util.IsValidLength(reflectType, disk.Description, "Description", resp) {
 		return false
 	}
 
@@ -166,7 +153,7 @@ func isValidDiskRequest(disk ui_virtz.DiskRequest, resp *restful.Response) bool 
 func isValidModifyDiskRequest(disk ui_virtz.ModifyDiskRequest, resp *restful.Response) bool {
 
 	reflectType := reflect.TypeOf(disk)
-	if !isValidLength(reflectType, disk.Name, "Name", resp) {
+	if !util.IsValidLength(reflectType, disk.Name, "Name", resp) {
 		return false
 	}
 
@@ -177,7 +164,7 @@ func isValidModifyDiskRequest(disk ui_virtz.ModifyDiskRequest, resp *restful.Res
 	}
 
 	if disk.Description != nil {
-		if !isValidLength(reflectType, *disk.Description, "Description", resp) {
+		if !util.IsValidLength(reflectType, *disk.Description, "Description", resp) {
 			return false
 		}
 	}
@@ -194,7 +181,7 @@ func isValidModifyDiskRequest(disk ui_virtz.ModifyDiskRequest, resp *restful.Res
 func isValidImageRequest(image ui_virtz.ImageRequest, resp *restful.Response) bool {
 
 	reflectType := reflect.TypeOf(image)
-	if !isValidLength(reflectType, image.Name, "Name", resp) {
+	if !util.IsValidLength(reflectType, image.Name, "Name", resp) {
 		return false
 	}
 
@@ -202,7 +189,7 @@ func isValidImageRequest(image ui_virtz.ImageRequest, resp *restful.Response) bo
 		return false
 	}
 
-	if !isValidLength(reflectType, image.Description, "Description", resp) {
+	if !util.IsValidLength(reflectType, image.Description, "Description", resp) {
 		return false
 	}
 
@@ -232,7 +219,7 @@ func isValidImageRequest(image ui_virtz.ImageRequest, resp *restful.Response) bo
 func isValidCloneImageRequest(image ui_virtz.CloneImageRequest, resp *restful.Response) bool {
 
 	reflectType := reflect.TypeOf(image)
-	if !isValidLength(reflectType, image.NewImageName, "DestinationImageName", resp) {
+	if !util.IsValidLength(reflectType, image.NewImageName, "DestinationImageName", resp) {
 		return false
 	}
 
@@ -246,7 +233,7 @@ func isValidCloneImageRequest(image ui_virtz.CloneImageRequest, resp *restful.Re
 func isValidModifyImageRequest(image ui_virtz.ModifyImageRequest, resp *restful.Response) bool {
 
 	reflectType := reflect.TypeOf(image)
-	if !isValidLength(reflectType, image.Name, "Name", resp) {
+	if !util.IsValidLength(reflectType, image.Name, "Name", resp) {
 		return false
 	}
 
@@ -257,7 +244,7 @@ func isValidModifyImageRequest(image ui_virtz.ModifyImageRequest, resp *restful.
 	}
 
 	if image.Description != nil {
-		if !isValidLength(reflectType, *image.Description, "Description", resp) {
+		if !util.IsValidLength(reflectType, *image.Description, "Description", resp) {
 			return false
 		}
 	}
@@ -292,7 +279,7 @@ func isValidImageSize(h *virtzhandler, namespace string, imageName string, newIm
 
 	oldImageSize, _ := strconv.ParseUint(image.Labels[virtzv1alpha1.VirtualizationImageStorage], 10, 32)
 	if int(oldImageSize) >= newImageSize {
-		resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
+		resp.WriteHeaderAndEntity(http.StatusForbidden, util.BadRequestError{
 			Reason: "The new image size must be larger than the old image size",
 		})
 		return false
@@ -309,7 +296,7 @@ func isValidDiskSize(h *virtzhandler, namespace string, diskName string, newDisk
 
 	oldDiskSize, _ := strconv.ParseUint(strings.Replace(diskVolume.Spec.Resources.Requests.Storage().String(), "Gi", "", -1), 10, 32)
 	if int(oldDiskSize) >= newDiskSize {
-		resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
+		resp.WriteHeaderAndEntity(http.StatusForbidden, util.BadRequestError{
 			Reason: "The new disk size must be larger than the old disk size",
 		})
 		return false
@@ -319,7 +306,7 @@ func isValidDiskSize(h *virtzhandler, namespace string, diskName string, newDisk
 
 func isValidImageType(imageType string, resp *restful.Response) bool {
 	if imageType != "cloud" && imageType != "iso" {
-		resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
+		resp.WriteHeaderAndEntity(http.StatusForbidden, util.BadRequestError{
 			Reason: "Image type should be 'cloud' or 'iso'",
 		})
 		return false
@@ -330,14 +317,14 @@ func isValidImageType(imageType string, resp *restful.Response) bool {
 func isValidMinioImageSize(minioClient *minio.Client, minioImageName string, resp *restful.Response) bool {
 	objectInfo, err := minioClient.StatObject(context.Background(), bucketName, minioImageName, minio.StatObjectOptions{})
 	if err != nil {
-		resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
+		resp.WriteHeaderAndEntity(http.StatusForbidden, util.BadRequestError{
 			Reason: "Minio image does not exist",
 		})
 		return false
 	}
 
 	if objectInfo.Size <= 0 {
-		resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
+		resp.WriteHeaderAndEntity(http.StatusForbidden, util.BadRequestError{
 			Reason: "Minio image '" + minioImageName + "' size should be larger than 0",
 		})
 		return false
@@ -355,7 +342,7 @@ func isValidOSFamily(osFamily string, resp *restful.Response) bool {
 		}
 	}
 
-	resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
+	resp.WriteHeaderAndEntity(http.StatusForbidden, util.BadRequestError{
 		Reason: "OS family should be one of the following: centos, debian, ubuntu, fedora, windows",
 	})
 
@@ -371,7 +358,7 @@ func isValidDiskDuplicated(diskSpecList interface{}, resp *restful.Response) boo
 				continue
 			}
 			if _, ok := diskMap[disk.ID]; ok {
-				resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
+				resp.WriteHeaderAndEntity(http.StatusForbidden, util.BadRequestError{
 					Reason: "Disk ID should be unique",
 				})
 				return false
@@ -386,7 +373,7 @@ func isValidDiskDuplicated(diskSpecList interface{}, resp *restful.Response) boo
 				continue
 			}
 			if _, ok := diskMap[disk.ID]; ok {
-				resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
+				resp.WriteHeaderAndEntity(http.StatusForbidden, util.BadRequestError{
 					Reason: "Disk ID should be unique",
 				})
 				return false
@@ -398,103 +385,4 @@ func isValidDiskDuplicated(diskSpecList interface{}, resp *restful.Response) boo
 		return false
 	}
 
-}
-
-// Return true if no duplicated key in Labels.
-func isValidLabelDuplicated(labels []ui_virtz.Label, resp *restful.Response) bool {
-	keyMap := make(map[string]bool)
-	for _, label := range labels { // Empty array is also valid.
-		if _, ok := keyMap[label.Key]; ok {
-			resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
-				Reason: "Label Key should be unique",
-			})
-			return false
-		}
-		if isValidLabel(label, resp) {
-			keyMap[label.Key] = true
-		} else {
-			return false
-		}
-	}
-	return true
-}
-
-// Return true if no duplicated key in NodeSelector.
-func isValidNodeSelectorDuplicated(nodeSelectors []ui_virtz.NodeSelector, resp *restful.Response) bool {
-	keyMap := make(map[string]bool)
-	for _, nodeSelector := range nodeSelectors { // Empty array is also valid.
-		if _, ok := keyMap[nodeSelector.Key]; ok {
-			resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
-				Reason: "NodeSelector Key should be unique",
-			})
-			return false
-		}
-		if isValidLabel(nodeSelector, resp) {
-			keyMap[nodeSelector.Key] = true
-		} else {
-			return false
-		}
-	}
-	return true
-}
-
-func isValidLabel(item interface{}, resp *restful.Response) bool {
-	var reflectType reflect.Type
-	var key string
-	var value string
-	switch label := item.(type) {
-	case ui_virtz.Label:
-		reflectType = reflect.TypeOf(label)
-		key = label.Key
-		value = label.Value
-	case ui_virtz.NodeSelector:
-		reflectType = reflect.TypeOf(label)
-		key = label.Key
-		value = label.Value
-	default:
-		resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
-			Reason: "Unknown type",
-		})
-		return false
-	}
-
-	if !isValidLength(reflectType, key, "Key", resp) {
-		return false
-	}
-
-	if !isValidKeyString(key, resp) {
-		return false
-	}
-
-	if !isValidLength(reflectType, value, "Value", resp) {
-		return false
-	}
-
-	if !isValidValueString(value, resp) {
-		return false
-	}
-
-	return true
-}
-
-func isValidKeyString(valueToValidate string, resp *restful.Response) bool {
-	validRegex := regexp.MustCompile("^[A-Za-z0-9-_./]+$")
-	if !validRegex.MatchString(valueToValidate) {
-		resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
-			Reason: "Valid characters: A-Z, a-z, 0-9, -(hyphen), _(underscore), .(dot), and /(slash)",
-		})
-		return false
-	}
-	return true
-}
-
-func isValidValueString(valueToValidate string, resp *restful.Response) bool {
-	validRegex := regexp.MustCompile("^[A-Za-z0-9-_.]*$") // Also match "", so use '*'
-	if !validRegex.MatchString(valueToValidate) {
-		resp.WriteHeaderAndEntity(http.StatusForbidden, BadRequestError{
-			Reason: "Valid characters: A-Z, a-z, 0-9, -(hyphen), _(underscore), and .(dot)",
-		})
-		return false
-	}
-	return true
 }

--- a/pkg/models/virtualization/types.go
+++ b/pkg/models/virtualization/types.go
@@ -14,14 +14,15 @@ const (
 
 // Virtual Machine
 type VirtualMachineRequest struct {
-	Name        string             `json:"name" description:"Virtual machine name. Valid characters: A-Z, a-z, 0-9, and -(hyphen)." maximum:"16"`
-	CpuCores    uint               `json:"cpu_cores" default:"1" description:"Virtual machine cpu cores" minimum:"1" maximum:"4"`
-	Memory      uint               `json:"memory" default:"1" description:"Virtual machine memory size, unit is GB" minimum:"1" maximum:"8"`
-	Description string             `json:"description" description:"Virtual machine description. Default is empty string." maximum:"128"`
-	Image       *ImageInfoResponse `json:"image" description:"Virtual machine image source"`
-	Disk        []DiskSpec         `json:"disk,omitempty" description:"Virtual machine disks"`
-	Guest       *GuestSpec         `json:"guest,omitempty" description:"Virtual machine guest operating system"`
-	Labels      map[string]string  `json:"labels,omitempty" description:"Virtual machine labels"`
+	Name         string             `json:"name" description:"Virtual machine name. Valid characters: A-Z, a-z, 0-9, and -(hyphen)." maximum:"16"`
+	CpuCores     uint               `json:"cpu_cores" default:"1" description:"Virtual machine cpu cores" minimum:"1" maximum:"4"`
+	Memory       uint               `json:"memory" default:"1" description:"Virtual machine memory size, unit is GB" minimum:"1" maximum:"8"`
+	Description  string             `json:"description" description:"Virtual machine description. Default is empty string." maximum:"128"`
+	Image        *ImageInfoResponse `json:"image" description:"Virtual machine image source"`
+	Disk         []DiskSpec         `json:"disk,omitempty" description:"Virtual machine disks"`
+	Guest        *GuestSpec         `json:"guest,omitempty" description:"Virtual machine guest operating system"`
+	Labels       map[string]string  `json:"labels,omitempty" description:"Virtual machine labels"`
+	NodeSelector string             `json:"node_selector,omitempty" description:"Virtual machine designated node"`
 }
 
 type DiskSpec struct {
@@ -43,27 +44,29 @@ type GuestSpec struct {
 }
 
 type ModifyVirtualMachineRequest struct {
-	Name        string            `json:"name,omitempty" description:"Virtual machine name. Valid characters: A-Z, a-z, 0-9, and -(hyphen)." maximum:"16"`
-	CpuCores    uint              `json:"cpu_cores,omitempty" default:"1" description:"Virtual machine cpu cores." minimum:"1" maximum:"4"`
-	Memory      uint              `json:"memory,omitempty" default:"1" description:"Virtual machine memory size, unit is GB." minimum:"1" maximum:"8"`
-	Disk        []ModifyDiskSpec  `json:"disk,omitempty" description:"Virtual machine disks"`
-	Description *string           `json:"description,omitempty" description:"Virtual machine description. Can be empty string." maximum:"128"`
-	Labels      map[string]string `json:"labels,omitempty" description:"Virtual machine labels. Can be empty map." maximum:"128"`
+	Name         string            `json:"name,omitempty" description:"Virtual machine name. Valid characters: A-Z, a-z, 0-9, and -(hyphen)." maximum:"16"`
+	CpuCores     uint              `json:"cpu_cores,omitempty" default:"1" description:"Virtual machine cpu cores." minimum:"1" maximum:"4"`
+	Memory       uint              `json:"memory,omitempty" default:"1" description:"Virtual machine memory size, unit is GB." minimum:"1" maximum:"8"`
+	Disk         []ModifyDiskSpec  `json:"disk,omitempty" description:"Virtual machine disks"`
+	Description  *string           `json:"description,omitempty" description:"Virtual machine description. Can be empty string." maximum:"128"`
+	Labels       map[string]string `json:"labels,omitempty" description:"Virtual machine labels. Can be empty map." maximum:"128"`
+	NodeSelector *string           `json:"node_selector,omitempty" description:"Virtual machine designated node"`
 }
 
 type VirtualMachineResponse struct {
-	ID          string             `json:"id" description:"Virtual machine id"`
-	Name        string             `json:"name" description:"Virtual machine name"`
-	Namespace   string             `json:"namespace" description:"Virtual machine namespace"`
-	Description string             `json:"description" description:"Virtual machine description"`
-	CpuCores    uint               `json:"cpu_cores" description:"Virtual machine cpu cores"`
-	Memory      uint               `json:"memory" description:"Virtual machine memory size"`
-	Image       *ImageInfoResponse `json:"image" description:"Virtual machine image source"`
-	Disks       []DiskResponse     `json:"disks" description:"Virtual machine disks"`
-	Status      VMStatus           `json:"status" description:"Virtual machine status"`
-	NodeName    string             `json:"node_name" description:"Virtual machine node"`
-	PodName     string             `json:"pod_name" description:"Virtual machine pod"`
-	Labels      map[string]string  `json:"labels" description:"Virtual machine labels"`
+	ID           string             `json:"id" description:"Virtual machine id"`
+	Name         string             `json:"name" description:"Virtual machine name"`
+	Namespace    string             `json:"namespace" description:"Virtual machine namespace"`
+	Description  string             `json:"description" description:"Virtual machine description"`
+	CpuCores     uint               `json:"cpu_cores" description:"Virtual machine cpu cores"`
+	Memory       uint               `json:"memory" description:"Virtual machine memory size"`
+	Image        *ImageInfoResponse `json:"image" description:"Virtual machine image source"`
+	Disks        []DiskResponse     `json:"disks" description:"Virtual machine disks"`
+	Status       VMStatus           `json:"status" description:"Virtual machine status"`
+	NodeName     string             `json:"node_name" description:"Virtual machine node"`
+	PodName      string             `json:"pod_name" description:"Virtual machine pod"`
+	Labels       map[string]string  `json:"labels" description:"Virtual machine labels"`
+	NodeSelector string             `json:"node_selector" description:"Virtual machine designated node"`
 }
 
 type VirtualMachineIDResponse struct {

--- a/pkg/models/virtualization/types.go
+++ b/pkg/models/virtualization/types.go
@@ -21,6 +21,7 @@ type VirtualMachineRequest struct {
 	Image       *ImageInfoResponse `json:"image" description:"Virtual machine image source"`
 	Disk        []DiskSpec         `json:"disk,omitempty" description:"Virtual machine disks"`
 	Guest       *GuestSpec         `json:"guest,omitempty" description:"Virtual machine guest operating system"`
+	Labels      map[string]string  `json:"labels,omitempty" description:"Virtual machine labels"`
 }
 
 type DiskSpec struct {
@@ -42,11 +43,12 @@ type GuestSpec struct {
 }
 
 type ModifyVirtualMachineRequest struct {
-	Name        string           `json:"name,omitempty" description:"Virtual machine name. Valid characters: A-Z, a-z, 0-9, and -(hyphen)." maximum:"16"`
-	CpuCores    uint             `json:"cpu_cores,omitempty" default:"1" description:"Virtual machine cpu cores." minimum:"1" maximum:"4"`
-	Memory      uint             `json:"memory,omitempty" default:"1" description:"Virtual machine memory size, unit is GB." minimum:"1" maximum:"8"`
-	Disk        []ModifyDiskSpec `json:"disk,omitempty" description:"Virtual machine disks"`
-	Description *string          `json:"description,omitempty" description:"Virtual machine description. Can be empty string." maximum:"128"`
+	Name        string            `json:"name,omitempty" description:"Virtual machine name. Valid characters: A-Z, a-z, 0-9, and -(hyphen)." maximum:"16"`
+	CpuCores    uint              `json:"cpu_cores,omitempty" default:"1" description:"Virtual machine cpu cores." minimum:"1" maximum:"4"`
+	Memory      uint              `json:"memory,omitempty" default:"1" description:"Virtual machine memory size, unit is GB." minimum:"1" maximum:"8"`
+	Disk        []ModifyDiskSpec  `json:"disk,omitempty" description:"Virtual machine disks"`
+	Description *string           `json:"description,omitempty" description:"Virtual machine description. Can be empty string." maximum:"128"`
+	Labels      map[string]string `json:"labels,omitempty" description:"Virtual machine labels. Can be empty map." maximum:"128"`
 }
 
 type VirtualMachineResponse struct {
@@ -61,6 +63,7 @@ type VirtualMachineResponse struct {
 	Status      VMStatus           `json:"status" description:"Virtual machine status"`
 	NodeName    string             `json:"node_name" description:"Virtual machine node"`
 	PodName     string             `json:"pod_name" description:"Virtual machine pod"`
+	Labels      map[string]string  `json:"labels" description:"Virtual machine labels"`
 }
 
 type VirtualMachineIDResponse struct {

--- a/pkg/models/virtualization/types.go
+++ b/pkg/models/virtualization/types.go
@@ -22,7 +22,7 @@ type VirtualMachineRequest struct {
 	Disk         []DiskSpec         `json:"disk,omitempty" description:"Virtual machine disks"`
 	Guest        *GuestSpec         `json:"guest,omitempty" description:"Virtual machine guest operating system"`
 	Labels       map[string]string  `json:"labels,omitempty" description:"Virtual machine labels"`
-	NodeSelector string             `json:"node_selector,omitempty" description:"Virtual machine designated node"`
+	NodeSelector map[string]string  `json:"node_selector,omitempty" description:"Virtual machine node selector"`
 }
 
 type DiskSpec struct {
@@ -49,8 +49,8 @@ type ModifyVirtualMachineRequest struct {
 	Memory       uint              `json:"memory,omitempty" default:"1" description:"Virtual machine memory size, unit is GB." minimum:"1" maximum:"8"`
 	Disk         []ModifyDiskSpec  `json:"disk,omitempty" description:"Virtual machine disks"`
 	Description  *string           `json:"description,omitempty" description:"Virtual machine description. Can be empty string." maximum:"128"`
-	Labels       map[string]string `json:"labels,omitempty" description:"Virtual machine labels. Can be empty map." maximum:"128"`
-	NodeSelector *string           `json:"node_selector,omitempty" description:"Virtual machine designated node"`
+	Labels       map[string]string `json:"labels,omitempty" description:"Virtual machine labels. Can be empty map."`
+	NodeSelector map[string]string `json:"node_selector,omitempty" description:"Virtual machine node selector."`
 }
 
 type VirtualMachineResponse struct {
@@ -66,7 +66,7 @@ type VirtualMachineResponse struct {
 	NodeName     string             `json:"node_name" description:"Virtual machine node"`
 	PodName      string             `json:"pod_name" description:"Virtual machine pod"`
 	Labels       map[string]string  `json:"labels" description:"Virtual machine labels"`
-	NodeSelector string             `json:"node_selector" description:"Virtual machine designated node"`
+	NodeSelector map[string]string  `json:"node_selector" description:"Virtual machine node selector"`
 }
 
 type VirtualMachineIDResponse struct {

--- a/pkg/models/virtualization/types.go
+++ b/pkg/models/virtualization/types.go
@@ -21,8 +21,8 @@ type VirtualMachineRequest struct {
 	Image        *ImageInfoResponse `json:"image" description:"Virtual machine image source"`
 	Disk         []DiskSpec         `json:"disk,omitempty" description:"Virtual machine disks"`
 	Guest        *GuestSpec         `json:"guest,omitempty" description:"Virtual machine guest operating system"`
-	Labels       map[string]string  `json:"labels,omitempty" description:"Virtual machine labels"`
-	NodeSelector map[string]string  `json:"node_selector,omitempty" description:"Virtual machine node selector"`
+	Labels       []Label            `json:"labels,omitempty" description:"Virtual machine labels"`
+	NodeSelector []NodeSelector     `json:"node_selector,omitempty" description:"Virtual machine node selector"`
 }
 
 type DiskSpec struct {
@@ -43,14 +43,24 @@ type GuestSpec struct {
 	Password string `json:"password" default:"abc1234" description:"Guest operating system password"`
 }
 
+type Label struct {
+	Key   string `json:"key" description:"Label key(unique key). Valid characters: A-Z, a-z, 0-9, -(hyphen), _(underscore), .(dot), and /(slash)." minimum:"1" maximum:"316"`
+	Value string `json:"value" description:"Label value. Valid characters: A-Z, a-z, 0-9, -(hyphen), _(underscore), and .(dot). Can be empty string." maximum:"63"`
+}
+
+type NodeSelector struct {
+	Key   string `json:"key" description:"NodeSelector key(unique key). Valid characters: A-Z, a-z, 0-9, -(hyphen), _(underscore), .(dot), and /(slash)." minimum:"1" maximum:"316"`
+	Value string `json:"value" description:"NodeSelector value. Valid characters: A-Z, a-z, 0-9, -(hyphen), _(underscore), and .(dot). Can be empty string." maximum:"63"`
+}
+
 type ModifyVirtualMachineRequest struct {
-	Name         string            `json:"name,omitempty" description:"Virtual machine name. Valid characters: A-Z, a-z, 0-9, and -(hyphen)." maximum:"16"`
-	CpuCores     uint              `json:"cpu_cores,omitempty" default:"1" description:"Virtual machine cpu cores." minimum:"1" maximum:"4"`
-	Memory       uint              `json:"memory,omitempty" default:"1" description:"Virtual machine memory size, unit is GB." minimum:"1" maximum:"8"`
-	Disk         []ModifyDiskSpec  `json:"disk,omitempty" description:"Virtual machine disks"`
-	Description  *string           `json:"description,omitempty" description:"Virtual machine description. Can be empty string." maximum:"128"`
-	Labels       map[string]string `json:"labels,omitempty" description:"Virtual machine labels. Can be empty map."`
-	NodeSelector map[string]string `json:"node_selector,omitempty" description:"Virtual machine node selector."`
+	Name         string           `json:"name,omitempty" description:"Virtual machine name. Valid characters: A-Z, a-z, 0-9, and -(hyphen)." maximum:"16"`
+	CpuCores     uint             `json:"cpu_cores,omitempty" default:"1" description:"Virtual machine cpu cores." minimum:"1" maximum:"4"`
+	Memory       uint             `json:"memory,omitempty" default:"1" description:"Virtual machine memory size, unit is GB." minimum:"1" maximum:"8"`
+	Disk         []ModifyDiskSpec `json:"disk,omitempty" description:"Virtual machine disks"`
+	Description  *string          `json:"description,omitempty" description:"Virtual machine description. Can be empty string." maximum:"128"`
+	Labels       []Label          `json:"labels,omitempty" description:"Virtual machine labels. Can be empty array."`
+	NodeSelector []NodeSelector   `json:"node_selector,omitempty" description:"Virtual machine node selector. Can be empty array."`
 }
 
 type VirtualMachineResponse struct {
@@ -65,8 +75,8 @@ type VirtualMachineResponse struct {
 	Status       VMStatus           `json:"status" description:"Virtual machine status"`
 	NodeName     string             `json:"node_name" description:"Virtual machine node"`
 	PodName      string             `json:"pod_name" description:"Virtual machine pod"`
-	Labels       map[string]string  `json:"labels" description:"Virtual machine labels"`
-	NodeSelector map[string]string  `json:"node_selector" description:"Virtual machine node selector"`
+	Labels       []Label            `json:"labels" description:"Virtual machine labels"`
+	NodeSelector []NodeSelector     `json:"node_selector" description:"Virtual machine node selector"`
 }
 
 type VirtualMachineIDResponse struct {

--- a/pkg/models/virtualization/virtualization.go
+++ b/pkg/models/virtualization/virtualization.go
@@ -690,7 +690,7 @@ func (v *virtualizationOperator) UpdateVirtualMachine(namespace string, name str
 						}
 						v.k8sclient.CoreV1().Pods(namespace).Update(context.Background(), &pod, metav1.UpdateOptions{})
 						break; // no need to iterate remaining pods
-					} else {
+					} else if err != nil {
 						klog.Error(err)
 					}
 				}

--- a/staging/src/kubesphere.io/api/virtualization/v1alpha1/virtualmachine_types.go
+++ b/staging/src/kubesphere.io/api/virtualization/v1alpha1/virtualmachine_types.go
@@ -111,6 +111,9 @@ type VirtualMachineSpec struct {
 	Hardware Hardware `json:"hardware,omitempty"`
 	// RunStrategy is the run strategy of the VirtualMachine.
 	RunStrategy string `json:"runStrategy,omitempty"`
+	// NodeSelector is a selector which must be true for the VirtualMachine to fit on a node.
+	// Selector which must match a node's labels for the VirtualMachine to be scheduled on that node.
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
 // +kubebuilder:resource:shortName={ksvm,ksvms}

--- a/staging/src/kubesphere.io/api/virtualization/v1alpha1/virtualmachine_types.go
+++ b/staging/src/kubesphere.io/api/virtualization/v1alpha1/virtualmachine_types.go
@@ -33,7 +33,6 @@ const (
 	VirtualizationDiskMinioImageName = "virtualization.ecpaas.io/disk-minio-image-name"
 	VirtualizationDiskMediaType      = "virtualization.ecpaas.io/disk-media-type"
 	VirtualizationDiskHotpluggable   = "virtualization.ecpaas.io/disk-hotpluggable"
-	VirtualizationNodeSelector       = "virtualization.ecpaas.io/node-selector"
 )
 
 const (

--- a/staging/src/kubesphere.io/api/virtualization/v1alpha1/virtualmachine_types.go
+++ b/staging/src/kubesphere.io/api/virtualization/v1alpha1/virtualmachine_types.go
@@ -33,6 +33,7 @@ const (
 	VirtualizationDiskMinioImageName = "virtualization.ecpaas.io/disk-minio-image-name"
 	VirtualizationDiskMediaType      = "virtualization.ecpaas.io/disk-media-type"
 	VirtualizationDiskHotpluggable   = "virtualization.ecpaas.io/disk-hotpluggable"
+	VirtualizationNodeSelector       = "virtualization.ecpaas.io/node-selector"
 )
 
 const (

--- a/staging/src/kubesphere.io/api/virtualization/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/kubesphere.io/api/virtualization/v1alpha1/zz_generated.deepcopy.go
@@ -593,6 +593,13 @@ func (in *VirtualMachineSpec) DeepCopyInto(out *VirtualMachineSpec) {
 		copy(*out, *in)
 	}
 	in.Hardware.DeepCopyInto(&out.Hardware)
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
Adds labels and node_selector fields to VM create and VM update APIs
- POST /kapis/virtualization.ecpaas.io/v1/namespaces/{namespace}/virtualmachines
- PUT /kapis/virtualization.ecpaas.io/v1/namespaces/{namespace}/virtualmachines/{id}

Adds labels and node_selctor fields to GET VM APIs
- GET /kapis/virtualization.ecpaas.io/v1/images
- GET /kapis/virtualization.ecpaas.io/v1/namespaces/{namespace}/images
- GET /kapis/virtualization.ecpaas.io/v1/namespaces/{namespace}/images/{id}