### PR TITLE
Feature/elvis vm gpu

### DIFF
--- a/api/ac-openapi-spec/swagger.json
+++ b/api/ac-openapi-spec/swagger.json
@@ -2113,7 +2113,7 @@
           "type": "string"
         },
         "size": {
-          "description": "Image size, unit is GB.",
+          "description": "Image size, unit is GB. Image size range is 10 ~ 80 GB. For 'windows' images , the default is 90 GB and range is \u003e= 90 GB.",
           "type": "integer",
           "format": "integer",
           "default": 20,
@@ -2177,7 +2177,7 @@
           "default": false
         },
         "size": {
-          "description": "Default image size, unit is GB.",
+          "description": "Default image size, unit is GB. Image size range is 10 ~ 80 GB. If os_family is 'windows', the default is 90 GB and range is \u003e= 90 GB.",
           "type": "integer",
           "format": "integer",
           "default": 20,
@@ -2260,7 +2260,7 @@
           "default": false
         },
         "size": {
-          "description": "Default image size, unit is GB",
+          "description": "Default image size, unit is GB. If os_family is 'windows', the default is 90 GB and range is \u003e= 90 GB.",
           "type": "integer",
           "format": "integer",
           "default": 20,
@@ -2474,7 +2474,7 @@
           "default": false
         },
         "size": {
-          "description": "Default image size, unit is GB and the size only can be increased.",
+          "description": "Default image size, unit is GB and the size only can be increased. For 'windows' images, the default is 90 GB and range is \u003e= 90 GB.",
           "type": "integer",
           "format": "integer",
           "default": 20,

--- a/api/ac-openapi-spec/swagger.json
+++ b/api/ac-openapi-spec/swagger.json
@@ -1429,6 +1429,29 @@
         }
       }
     },
+    "/kapis/virtualization.ecpaas.io/v1/virtualmachines/gpus": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "Virtualization Virtual Machine"
+        ],
+        "summary": "List all available GPUs",
+        "operationId": "ListAvailableGPUs",
+        "responses": {
+          "200": {
+            "description": "ok",
+            "schema": {
+              "$ref": "#/definitions/virtualization.ListAvailableGPUResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
     "/kapis/virtualization.ecpaas.io/v1alpha1/minio/image": {
       "post": {
         "consumes": [
@@ -1992,6 +2015,59 @@
         }
       }
     },
+    "virtualization.GPU": {
+      "required": [
+        "model",
+        "quantity"
+      ],
+      "properties": {
+        "model": {
+          "description": "GPU model to be used on this virtual machine. Valid characters: A-Z, a-z, 0-9, /(slash), _(underscore), and -(hyphen). And must start and end with alphanumeric character.",
+          "type": "string",
+          "maximum": 317
+        },
+        "quantity": {
+          "description": "GPU quantity to be used on this virtual machine. Must not exceed maximum available GPUs.",
+          "type": "integer",
+          "format": "int32",
+          "minimum": 0
+        }
+      }
+    },
+    "virtualization.GPUResourceResponse": {
+      "required": [
+        "model",
+        "quantity"
+      ],
+      "properties": {
+        "model": {
+          "description": "Model of available GPU.",
+          "type": "string"
+        },
+        "quantity": {
+          "description": "Quantity of available GPU.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "virtualization.GPUResponse": {
+      "required": [
+        "model",
+        "quantity"
+      ],
+      "properties": {
+        "model": {
+          "description": "GPU model to be used on this virtual machine.",
+          "type": "string"
+        },
+        "quantity": {
+          "description": "GPU quantity to be used on this virtual machine.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
     "virtualization.GuestSpec": {
       "required": [
         "username",
@@ -2242,6 +2318,26 @@
         }
       }
     },
+    "virtualization.ListAvailableGPUResponse": {
+      "required": [
+        "total_count",
+        "items"
+      ],
+      "properties": {
+        "items": {
+          "description": "List of available GPUs on the cluster.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/virtualization.GPUResourceResponse"
+          }
+        },
+        "total_count": {
+          "description": "Total number of available GPUs on the cluster.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
     "virtualization.ListDiskResponse": {
       "required": [
         "total_count",
@@ -2409,6 +2505,10 @@
             "$ref": "#/definitions/virtualization.ModifyDiskSpec"
           }
         },
+        "gpus": {
+          "description": "Specify the GPU device(s) to be attached to the virtual machine.",
+          "$ref": "#/definitions/virtualization.GPU"
+        },
         "labels": {
           "description": "Virtual machine labels. Can be empty array.",
           "type": "array",
@@ -2513,6 +2613,10 @@
             "$ref": "#/definitions/virtualization.DiskSpec"
           }
         },
+        "gpus": {
+          "description": "Specify the GPU device(s) to be attached to the virtual machine.",
+          "$ref": "#/definitions/virtualization.GPU"
+        },
         "guest": {
           "description": "Virtual machine guest operating system",
           "$ref": "#/definitions/virtualization.GuestSpec"
@@ -2558,6 +2662,7 @@
         "description",
         "cpu_cores",
         "memory",
+        "gpus",
         "image",
         "disks",
         "status",
@@ -2582,6 +2687,10 @@
           "items": {
             "$ref": "#/definitions/virtualization.DiskResponse"
           }
+        },
+        "gpus": {
+          "description": "Specify the GPU device(s) to be attached to the virtual machine.",
+          "$ref": "#/definitions/virtualization.GPUResponse"
         },
         "id": {
           "description": "Virtual machine id",

--- a/config/crds/virtualization.ecpaas.io_virtualmachines.yaml
+++ b/config/crds/virtualization.ecpaas.io_virtualmachines.yaml
@@ -139,6 +139,105 @@ spec:
                 properties:
                   domain:
                     properties:
+                      clock:
+                        description: Clock sets the clock and timers of the vmi.
+                        properties:
+                          timer:
+                            description: Timer specifies whih timers are attached
+                              to the vmi.
+                            properties:
+                              hpet:
+                                description: HPET (High Precision Event Timer) - multiple
+                                  timers with periodic interrupts.
+                                properties:
+                                  present:
+                                    description: Enabled set to false makes sure that
+                                      the machine type or a preset can't add the timer.
+                                      Defaults to true.
+                                    type: boolean
+                                  tickPolicy:
+                                    description: TickPolicy determines what happens
+                                      when QEMU misses a deadline for injecting a
+                                      tick to the guest. One of "delay", "catchup",
+                                      "merge", "discard".
+                                    type: string
+                                type: object
+                              hyperv:
+                                description: Hyperv (Hypervclock) - lets guests read
+                                  the host’s wall clock time (paravirtualized). For
+                                  windows guests.
+                                properties:
+                                  present:
+                                    description: Enabled set to false makes sure that
+                                      the machine type or a preset can't add the timer.
+                                      Defaults to true.
+                                    type: boolean
+                                type: object
+                              kvm:
+                                description: "KVM \t(KVM clock) - lets guests read
+                                  the host’s wall clock time (paravirtualized). For
+                                  linux guests."
+                                properties:
+                                  present:
+                                    description: Enabled set to false makes sure that
+                                      the machine type or a preset can't add the timer.
+                                      Defaults to true.
+                                    type: boolean
+                                type: object
+                              pit:
+                                description: PIT (Programmable Interval Timer) - a
+                                  timer with periodic interrupts.
+                                properties:
+                                  present:
+                                    description: Enabled set to false makes sure that
+                                      the machine type or a preset can't add the timer.
+                                      Defaults to true.
+                                    type: boolean
+                                  tickPolicy:
+                                    description: TickPolicy determines what happens
+                                      when QEMU misses a deadline for injecting a
+                                      tick to the guest. One of "delay", "catchup",
+                                      "discard".
+                                    type: string
+                                type: object
+                              rtc:
+                                description: RTC (Real Time Clock) - a continuously
+                                  running timer with periodic interrupts.
+                                properties:
+                                  present:
+                                    description: Enabled set to false makes sure that
+                                      the machine type or a preset can't add the timer.
+                                      Defaults to true.
+                                    type: boolean
+                                  tickPolicy:
+                                    description: TickPolicy determines what happens
+                                      when QEMU misses a deadline for injecting a
+                                      tick to the guest. One of "delay", "catchup".
+                                    type: string
+                                  track:
+                                    description: Track the guest or the wall clock.
+                                    type: string
+                                type: object
+                            type: object
+                          timezone:
+                            description: Timezone sets the guest clock to the specified
+                              timezone. Zone name follows the TZ environment variable
+                              format (e.g. 'America/New_York').
+                            type: string
+                          utc:
+                            description: UTC sets the guest clock to UTC on each boot.
+                              If an offset is specified, guest changes to the clock
+                              will be kept during reboots and are not reset.
+                            properties:
+                              offsetSeconds:
+                                description: OffsetSeconds specifies an offset in
+                                  seconds, relative to UTC. If set, guest changes
+                                  to the clock will be kept during reboots and not
+                                  reset.
+                                type: integer
+                            type: object
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       cpu:
                         properties:
                           cores:
@@ -800,6 +899,78 @@ spec:
                                   true.
                                 type: boolean
                             type: object
+                        type: object
+                      firmware:
+                        description: Firmware.
+                        properties:
+                          bootloader:
+                            description: Settings to control the bootloader that is
+                              used.
+                            properties:
+                              bios:
+                                description: If set (default), BIOS will be used.
+                                properties:
+                                  useSerial:
+                                    description: If set, the BIOS output will be transmitted
+                                      over serial
+                                    type: boolean
+                                type: object
+                              efi:
+                                description: If set, EFI will be used instead of BIOS.
+                                properties:
+                                  secureBoot:
+                                    description: If set, SecureBoot will be enabled
+                                      and the OVMF roms will be swapped for SecureBoot-enabled
+                                      ones. Requires SMM to be enabled. Defaults to
+                                      true
+                                    type: boolean
+                                type: object
+                            type: object
+                          kernelBoot:
+                            description: Settings to set the kernel for booting.
+                            properties:
+                              container:
+                                description: Container defines the container that
+                                  containes kernel artifacts
+                                properties:
+                                  image:
+                                    description: Image that contains initrd / kernel
+                                      files.
+                                    type: string
+                                  imagePullPolicy:
+                                    description: 'Image pull policy. One of Always,
+                                      Never, IfNotPresent. Defaults to Always if :latest
+                                      tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    type: string
+                                  imagePullSecret:
+                                    description: ImagePullSecret is the name of the
+                                      Docker registry secret required to pull the
+                                      image. The secret must already exist.
+                                    type: string
+                                  initrdPath:
+                                    description: the fully-qualified path to the ramdisk
+                                      image in the host OS
+                                    type: string
+                                  kernelPath:
+                                    description: The fully-qualified path to the kernel
+                                      image in the host OS
+                                    type: string
+                                required:
+                                - image
+                                type: object
+                              kernelArgs:
+                                description: Arguments to be passed to the kernel
+                                  at boot time
+                                type: string
+                            type: object
+                          serial:
+                            description: The system-serial-number in SMBIOS
+                            type: string
+                          uuid:
+                            description: UUID reported by the vmi bios. Defaults to
+                              a random generated uid.
+                            type: string
                         type: object
                       machine:
                         description: Machine type.

--- a/pkg/controller/virtualization/virtualmachine/virtualmachine_controller.go
+++ b/pkg/controller/virtualization/virtualmachine/virtualmachine_controller.go
@@ -550,6 +550,7 @@ func applyVirtualMachineSpec(kvvmSpec *kvapi.VirtualMachineSpec, virtzSpec virtz
 	kvvmSpec.Template.Spec.Domain.Resources.Requests = virtzSpec.Hardware.Domain.Resources.Requests
 	kvvmSpec.Template.Spec.Domain.CPU = &kvapi.CPU{}
 	kvvmSpec.Template.Spec.Domain.CPU.Cores = virtzSpec.Hardware.Domain.CPU.Cores
+	kvvmSpec.Template.Spec.Domain.Devices.GPUs = virtzSpec.Hardware.Domain.Devices.GPUs
 
 	kvvmSpec.Template.Spec.Hostname = virtzSpec.Hardware.Hostname
 

--- a/pkg/controller/virtualization/virtualmachine/virtualmachine_controller.go
+++ b/pkg/controller/virtualization/virtualmachine/virtualmachine_controller.go
@@ -548,6 +548,7 @@ func applyVirtualMachineSpec(kvvmSpec *kvapi.VirtualMachineSpec, virtzSpec virtz
 			interfaceMehod := getInterfaceMethod(iface)
 			kvvmSpec.Template.Spec.Domain.Devices.Interfaces[i] = kvapi.Interface{
 				Name:                   iface.Name,
+				Model:                  iface.Model,
 				InterfaceBindingMethod: interfaceMehod,
 			}
 		}
@@ -613,6 +614,16 @@ func applyVirtualMachineSpec(kvvmSpec *kvapi.VirtualMachineSpec, virtzSpec virtz
 	if virtzSpec.Hardware.Domain.Machine != nil {
 		kvvmSpec.Template.Spec.Domain.Machine = &kvapi.Machine{}
 		kvvmSpec.Template.Spec.Domain.Machine = virtzSpec.Hardware.Domain.Machine
+	}
+
+	if virtzSpec.Hardware.Domain.Firmware != nil {
+		kvvmSpec.Template.Spec.Domain.Firmware = &kvapi.Firmware{}
+		kvvmSpec.Template.Spec.Domain.Firmware = virtzSpec.Hardware.Domain.Firmware
+	}
+
+	if virtzSpec.Hardware.Domain.Clock != nil {
+		kvvmSpec.Template.Spec.Domain.Clock = &kvapi.Clock{}
+		kvvmSpec.Template.Spec.Domain.Clock = virtzSpec.Hardware.Domain.Clock
 	}
 
 	if virtzSpec.Hardware.Domain.Features != nil {

--- a/pkg/controller/virtualization/virtualmachine/virtualmachine_controller.go
+++ b/pkg/controller/virtualization/virtualmachine/virtualmachine_controller.go
@@ -223,6 +223,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 	modifiedFlag := false
 
+	// update GPUs
+	if !reflect.DeepEqual(vm.Spec.Hardware.Domain.Devices.GPUs, kvVM.Spec.Template.Spec.Domain.Devices.GPUs) {
+		kvVM.Spec.Template.Spec.Domain.Devices.GPUs = vm.Spec.Hardware.Domain.Devices.GPUs
+		modifiedFlag = true
+	}
+
 	// update labels
 	if !reflect.DeepEqual(vm.Labels, kvVM.Spec.Template.ObjectMeta.Labels) {
 		kvVM.Spec.Template.ObjectMeta.Labels = vm.Labels

--- a/pkg/controller/virtualization/virtualmachine/virtualmachine_controller.go
+++ b/pkg/controller/virtualization/virtualmachine/virtualmachine_controller.go
@@ -6,6 +6,7 @@ package virtualmachine
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -33,6 +34,7 @@ import (
 
 	storage "k8s.io/api/storage/v1"
 	virtzv1alpha1 "kubesphere.io/api/virtualization/v1alpha1"
+	ui_virtz "kubesphere.io/kubesphere/pkg/models/virtualization"
 )
 
 const (
@@ -525,7 +527,7 @@ func getVirtualMachineStatus(virtClient kubecli.KubevirtClient, namespace string
 
 }
 
-func applyVirtualMachineSpec(kvvmSpec *kvapi.VirtualMachineSpec, virtzSpec virtzv1alpha1.VirtualMachineSpec) {
+func applyVirtualMachineSpec(kvvmSpec *kvapi.VirtualMachineSpec, virtzSpec virtzv1alpha1.VirtualMachineSpec, osType string) {
 
 	runStrategy := kvapi.RunStrategyAlways
 	if virtzSpec.RunStrategy == virtzv1alpha1.VirtualMachineRunStrategyAlways {
@@ -737,7 +739,7 @@ func applyVirtualMachineSpec(kvvmSpec *kvapi.VirtualMachineSpec, virtzSpec virtz
 						newDisk.BootOrder = &bootorder
 					}
 
-					if diskMediaType == "cdrom" {
+					if diskMediaType == "cdrom" || osType == "windows" {
 						newDisk.DiskDevice = kvapi.DiskDevice{
 							CDRom: &kvapi.CDRomTarget{
 								Bus: "sata",
@@ -831,7 +833,13 @@ func createVirtualMachine(virtClient kubecli.KubevirtClient, virtzVM *virtzv1alp
 		UID:                virtzVM.UID,
 	})
 
-	applyVirtualMachineSpec(&kvVM.Spec, virtzVM.Spec)
+	imageInfo := ui_virtz.ImageInfo{}
+	err := json.Unmarshal([]byte(virtzVM.Annotations[virtzv1alpha1.VirtualizationImageInfo]), &imageInfo)
+	if err != nil {
+		klog.Infof(err.Error())
+		return err
+	}
+	applyVirtualMachineSpec(&kvVM.Spec, virtzVM.Spec, imageInfo.System)
 	// Copy labels from "ksvm" to "vm", so that these labels go to vmi and virt-launcher pod
 	// doesn't matter whether virtzVM.Labels is nil
 	kvVM.Spec.Template.ObjectMeta.Labels = virtzVM.Labels

--- a/pkg/controller/virtualization/virtualmachine/virtualmachine_controller.go
+++ b/pkg/controller/virtualization/virtualmachine/virtualmachine_controller.go
@@ -739,9 +739,15 @@ func applyVirtualMachineSpec(kvvmSpec *kvapi.VirtualMachineSpec, virtzSpec virtz
 						newDisk.BootOrder = &bootorder
 					}
 
-					if diskMediaType == "cdrom" || osType == "windows" {
+					if diskMediaType == "cdrom" {
 						newDisk.DiskDevice = kvapi.DiskDevice{
 							CDRom: &kvapi.CDRomTarget{
+								Bus: "sata",
+							},
+						}
+					} else if osType == "windows" {
+						newDisk.DiskDevice = kvapi.DiskDevice{
+							Disk: &kvapi.DiskTarget{
 								Bus: "sata",
 							},
 						}

--- a/pkg/kapis/util/validation.go
+++ b/pkg/kapis/util/validation.go
@@ -106,6 +106,18 @@ func IsValidString(valueToValidate string, resp *restful.Response) bool {
 
 }
 
+// Valid characters: A-Z, a-z, 0-9, and -(hyphen)
+func IsValidCaseInsensitiveString(valueToValidate string, resp *restful.Response) bool {
+	validRegex := regexp.MustCompile(`^[A-Za-z0-9]([-A-Za-z0-9]*[A-Za-z0-9])?(\\.[A-Za-z0-9]([-A-Za-z0-9]*[A-Za-z0-9])?)*$`)
+	if !validRegex.MatchString(valueToValidate) {
+		resp.WriteHeaderAndEntity(http.StatusBadRequest, BadRequestError{
+			Reason: "Allowed characters: uppercase and lowercase letters (A-Z, a-z), numbers (0-9), and hyphens (-). And must start and end with alphanumeric charactors.",
+		})
+		return false
+	}
+	return true
+}
+
 func IsValidCIDR(cidr string, resp *restful.Response) bool {
 	_, _, err := net.ParseCIDR(cidr)
 	if err != nil {

--- a/pkg/kapis/virtualization/v1/handler.go
+++ b/pkg/kapis/virtualization/v1/handler.go
@@ -654,7 +654,7 @@ func (h *virtzhandler) UpdateImage(req *restful.Request, resp *restful.Response)
 	}
 
 	if ui_image.Size != 0 {
-		if !isValidImageSize(h, namespace, imageName, int(ui_image.Size), resp) {
+		if !isValidImageSize(h, namespace, imageName, int(ui_image.Size), ui_image, resp) {
 			return
 		}
 	}

--- a/pkg/kapis/virtualization/v1/handler.go
+++ b/pkg/kapis/virtualization/v1/handler.go
@@ -61,7 +61,7 @@ func (h *virtzhandler) CreateVirtualMahcine(req *restful.Request, resp *restful.
 		return
 	}
 
-	if !isValidVirtualMachine(ui_vm, resp) {
+	if !isValidVirtualMachine(h, ui_vm, resp) {
 		return
 	}
 
@@ -102,7 +102,7 @@ func (h *virtzhandler) UpdateVirtualMahcine(req *restful.Request, resp *restful.
 		return
 	}
 
-	if !isValidModifyVirtualMachine(ui_vm, resp) {
+	if !isValidModifyVirtualMachine(h, ui_vm, resp) {
 		return
 	}
 
@@ -226,19 +226,27 @@ func (h *virtzhandler) getUIVirtualMachineResponse(vm *virtzv1alpha1.VirtualMach
 	}
 }
 
-func (h *virtzhandler) getVirtualMachineGPUResponse(gpus []kvapi.GPU) []ui_virtz.GPUResponse {
-	returnArray := make([]ui_virtz.GPUResponse, 0)
+func (h *virtzhandler) getVirtualMachineGPUResponse(gpus []kvapi.GPU) ui_virtz.GPUResponse {
+	// Traverse all gpus from VM, count up the quantity
+	// If multiple GPU kinds, only return the GPU with largest quantity, for now
+	count := make(map[string]int, 0)
+	max := "none"
+	count[max] = 0
 	for _, gpu := range gpus {
-		response := ui_virtz.GPUResponse{
-			Name: gpu.Name,
-			DeviceName: gpu.DeviceName,
-			VGPUDisplay: *gpu.VirtualGPUOptions.Display.Enabled,
-			VGPURamFB: *gpu.VirtualGPUOptions.Display.RamFB.Enabled,
+		if _, ok := count[gpu.DeviceName]; !ok {
+			count[gpu.DeviceName] = 1
+		} else {
+			count[gpu.DeviceName]++
 		}
-		returnArray = append(returnArray, response)
+		if count[gpu.DeviceName] > count[max] {
+			max = gpu.DeviceName
+		}
 	}
 
-	return returnArray
+	return ui_virtz.GPUResponse{
+		Model:    max,
+		Quantity: count[max],
+	}
 }
 
 func (h *virtzhandler) getVirtualMachineNode(namespace, name string) string {
@@ -424,23 +432,9 @@ func (h *virtzhandler) DeleteVirtualMachine(req *restful.Request, resp *restful.
 }
 
 func (h *virtzhandler) ListAvailableGPUs(req *restful.Request, resp *restful.Response) {
-	availableGPUs := make([]ui_virtz.GPUNameResponse, 0)
-	nodes, err := h.k8sClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	availableGPUs, err := h.virtz.ListAvailableGPUs()
 	if err != nil {
 		return
-	}
-	for _, node := range nodes.Items {
-		allocatable := node.Status.Allocatable
-		for key, value := range allocatable {
-			if strings.Contains(key.String(), "gpu/") {
-				if quantity, flag := value.AsInt64();flag && quantity > 0 {
-					response := ui_virtz.GPUNameResponse{
-						DeviceName: key.String(),
-					}
-					availableGPUs = append(availableGPUs, response)
-				}
-			}
-		}
 	}
 
 	resp.WriteEntity(ui_virtz.ListAvailableGPUResponse{

--- a/pkg/kapis/virtualization/v1/handler.go
+++ b/pkg/kapis/virtualization/v1/handler.go
@@ -102,7 +102,7 @@ func (h *virtzhandler) UpdateVirtualMahcine(req *restful.Request, resp *restful.
 		return
 	}
 
-	if !isValidModifyVirtualMachine(h, ui_vm, resp) {
+	if !isValidModifyVirtualMachine(h, ui_vm, namespace, vmName, resp) {
 		return
 	}
 
@@ -432,7 +432,7 @@ func (h *virtzhandler) DeleteVirtualMachine(req *restful.Request, resp *restful.
 }
 
 func (h *virtzhandler) ListAvailableGPUs(req *restful.Request, resp *restful.Response) {
-	availableGPUs, err := h.virtz.ListAvailableGPUs()
+	availableGPUs, err := h.virtz.ListAvailableGPUs("", "")
 	if err != nil {
 		return
 	}

--- a/pkg/kapis/virtualization/v1/handler.go
+++ b/pkg/kapis/virtualization/v1/handler.go
@@ -24,6 +24,7 @@ import (
 	"kubesphere.io/kubesphere/pkg/informers"
 	"kubesphere.io/kubesphere/pkg/kapis/util"
 	"kubesphere.io/kubesphere/pkg/models/quotas"
+	kvapi "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
 	kubesphere "kubesphere.io/kubesphere/pkg/client/clientset/versioned"
@@ -214,6 +215,7 @@ func (h *virtzhandler) getUIVirtualMachineResponse(vm *virtzv1alpha1.VirtualMach
 		Description:  vm.Annotations[virtzv1alpha1.VirtualizationDescription],
 		CpuCores:     uint(vm.Spec.Hardware.Domain.CPU.Cores),
 		Memory:       uint(memory),
+		GPUs:         h.getVirtualMachineGPUResponse(vm.Spec.Hardware.Domain.Devices.GPUs),
 		Image:        &ui_image_spec,
 		Disks:        h.getUIDisksResponse(vm),
 		Status:       ui_vm_status,
@@ -222,6 +224,21 @@ func (h *virtzhandler) getUIVirtualMachineResponse(vm *virtzv1alpha1.VirtualMach
 		Labels:       getLabelResponse(vm.Labels),
 		NodeSelector: getNodeSelectorResponse(vm.Spec.NodeSelector),
 	}
+}
+
+func (h *virtzhandler) getVirtualMachineGPUResponse(gpus []kvapi.GPU) []ui_virtz.GPUResponse {
+	returnArray := make([]ui_virtz.GPUResponse, 0)
+	for _, gpu := range gpus {
+		response := ui_virtz.GPUResponse{
+			Name: gpu.Name,
+			DeviceName: gpu.DeviceName,
+			VGPUDisplay: *gpu.VirtualGPUOptions.Display.Enabled,
+			VGPURamFB: *gpu.VirtualGPUOptions.Display.RamFB.Enabled,
+		}
+		returnArray = append(returnArray, response)
+	}
+
+	return returnArray
 }
 
 func (h *virtzhandler) getVirtualMachineNode(namespace, name string) string {
@@ -404,6 +421,32 @@ func (h *virtzhandler) DeleteVirtualMachine(req *restful.Request, resp *restful.
 	}
 
 	resp.WriteHeader(http.StatusOK)
+}
+
+func (h *virtzhandler) ListAvailableGPUs(req *restful.Request, resp *restful.Response) {
+	availableGPUs := make([]ui_virtz.GPUNameResponse, 0)
+	nodes, err := h.k8sClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return
+	}
+	for _, node := range nodes.Items {
+		allocatable := node.Status.Allocatable
+		for key, value := range allocatable {
+			if strings.Contains(key.String(), "gpu/") {
+				if quantity, flag := value.AsInt64();flag && quantity > 0 {
+					response := ui_virtz.GPUNameResponse{
+						DeviceName: key.String(),
+					}
+					availableGPUs = append(availableGPUs, response)
+				}
+			}
+		}
+	}
+
+	resp.WriteEntity(ui_virtz.ListAvailableGPUResponse{
+		TotalCount: len(availableGPUs),
+		Items:      availableGPUs,
+	})
 }
 
 func (h *virtzhandler) CreateDisk(req *restful.Request, resp *restful.Response) {

--- a/pkg/kapis/virtualization/v1/register.go
+++ b/pkg/kapis/virtualization/v1/register.go
@@ -121,7 +121,7 @@ func AddToContainer(container *restful.Container, minioClient *minio.Client, kub
 		Returns(http.StatusNotFound, api.StatusNotFound, nil).
 		Returns(http.StatusInternalServerError, api.StatusInternalServerError, nil))
 
-	webservice.Route(webservice.GET("/gpus").
+	webservice.Route(webservice.GET("/virtualmachines/gpus").
 		To(handler.ListAvailableGPUs).
 		Doc("List all available GPUs").
 		Returns(http.StatusOK, api.StatusOK, ui_virtz.ListAvailableGPUResponse{}).

--- a/pkg/kapis/virtualization/v1/register.go
+++ b/pkg/kapis/virtualization/v1/register.go
@@ -121,6 +121,13 @@ func AddToContainer(container *restful.Container, minioClient *minio.Client, kub
 		Returns(http.StatusNotFound, api.StatusNotFound, nil).
 		Returns(http.StatusInternalServerError, api.StatusInternalServerError, nil))
 
+	webservice.Route(webservice.GET("/gpus").
+		To(handler.ListAvailableGPUs).
+		Doc("List all available GPUs").
+		Returns(http.StatusOK, api.StatusOK, ui_virtz.ListAvailableGPUResponse{}).
+		Returns(http.StatusInternalServerError, api.StatusInternalServerError, nil).
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.VirtualMachineTag}))
+
 	webservice.Route(webservice.POST("/namespaces/{namespace}/disks").
 		To(handler.CreateDisk).
 		Param(webservice.PathParameter("namespace", "namespace name")).

--- a/pkg/kapis/virtualization/v1/validation.go
+++ b/pkg/kapis/virtualization/v1/validation.go
@@ -61,7 +61,7 @@ func isValidString(valueToValidate string, resp *restful.Response) bool {
 	return true
 }
 
-func isValidVirtualMachine(vm ui_virtz.VirtualMachineRequest, resp *restful.Response) bool {
+func isValidVirtualMachine(h *virtzhandler, vm ui_virtz.VirtualMachineRequest, resp *restful.Response) bool {
 
 	reflectType := reflect.TypeOf(vm)
 	if !util.IsValidLength(reflectType, vm.Name, "Name", resp) {
@@ -84,64 +84,64 @@ func isValidVirtualMachine(vm ui_virtz.VirtualMachineRequest, resp *restful.Resp
 		return false
 	}
 
-	if !isValidGPURequest(vm.GPUs, resp) {
+	if !isValidGPURequest(h, vm.GPUs, resp) {
 		return false
 	}
 
 	return true
 }
 
-func isValidGPURequest(gpus []ui_virtz.GPU, resp *restful.Response) bool {
-	if gpus != nil {
-		primaryGPU := false
-		nameMap := make(map[string]bool, 0)
-		reflectType := reflect.TypeOf(ui_virtz.GPU{})
-		for _, gpu := range gpus {
-			// Name
-			if !util.IsValidCaseInsensitiveString(gpu.Name, resp) {
-				return false
+func isValidGPURequest(h *virtzhandler, gpuRequest *ui_virtz.GPU, resp *restful.Response) bool {
+	if gpuRequest != nil {
+		// Quantity, check first, quantity <= 0 is equal to not using any GPU, which will be ignored.
+		if gpuRequest.Quantity <= 0 {
+			return true
+		}
+
+		// Model format check, e.g. "gpu/nvidia.com.A400"
+		errMsg := k8svalidation.IsQualifiedName(gpuRequest.Model) // Has built-in length check
+		if len(errMsg) > 0 {
+			errorReason := "Invalid Model: '" + gpuRequest.Model + "'"
+			for _, msg := range errMsg {
+				errorReason += ", " + msg
 			}
-			if !util.IsValidLength(reflectType, gpu.Name, "Name", resp) {
-				return false
-			}
-			if _, ok := nameMap[gpu.Name]; ok {
-				resp.WriteHeaderAndEntity(http.StatusBadRequest, util.BadRequestError{
-					Reason: "GPU identification name cannot duplicate",
-				})
-				return false
-			} else {
-				nameMap[gpu.Name] = true
-			}
-			// DeviceName, e.g. "nvidia.com/GRID_A100D-40C"
-			errMsg := k8svalidation.IsQualifiedName(gpu.DeviceName) // Has built-in length check
-			if len(errMsg) > 0 {
-				errorReason := "Invalid DeviceName: '" + gpu.DeviceName + "'"
-				for _, msg := range errMsg {
-					errorReason += ", " + msg
-				}
-				resp.WriteHeaderAndEntity(http.StatusBadRequest, util.BadRequestError{
-					Reason: errorReason,
-				})
-				return false
-			}
-			// VGPUDisplay
-			// VGPURamFB
-			if gpu.VGPURamFB == nil || *gpu.VGPURamFB {
-				if !primaryGPU {
-					primaryGPU = true
-				} else {
+			resp.WriteHeaderAndEntity(http.StatusBadRequest, util.BadRequestError{
+				Reason: errorReason,
+			})
+			return false
+		}
+
+		availableGPUs, err := h.virtz.ListAvailableGPUs()
+		if err != nil {
+			resp.WriteHeaderAndEntity(http.StatusBadRequest, util.BadRequestError{
+				Reason: "Invalid request: can't find available GPUs",
+			})
+			return false
+		}
+		found := false
+		for _, availableGPU := range availableGPUs {
+			if availableGPU.Model == gpuRequest.Model {
+				if gpuRequest.Quantity > availableGPU.Quantity {
 					resp.WriteHeaderAndEntity(http.StatusBadRequest, util.BadRequestError{
-						Reason: "Only one GPU can enable VGPURamFB setting",
+						Reason: "Invalid Quantity: '" + strconv.Itoa(gpuRequest.Quantity) + "' exceeds maximun available GPU quantity",
 					})
 					return false
 				}
+				found = true
+				break
 			}
+		}
+		if !found {
+			resp.WriteHeaderAndEntity(http.StatusBadRequest, util.BadRequestError{
+				Reason: "Invalid Model: '" + gpuRequest.Model + "' not found in available GPU list",
+			})
+			return false
 		}
 	}
 	return true
 }
 
-func isValidModifyVirtualMachine(vm ui_virtz.ModifyVirtualMachineRequest, resp *restful.Response) bool {
+func isValidModifyVirtualMachine(h *virtzhandler, vm ui_virtz.ModifyVirtualMachineRequest, resp *restful.Response) bool {
 
 	reflectType := reflect.TypeOf(vm)
 	if !util.IsValidLength(reflectType, vm.Name, "Name", resp) {
@@ -172,7 +172,7 @@ func isValidModifyVirtualMachine(vm ui_virtz.ModifyVirtualMachineRequest, resp *
 		}
 	}
 
-	if !isValidGPURequest(vm.GPUs, resp) {
+	if !isValidGPURequest(h, vm.GPUs, resp) {
 		return false
 	}
 

--- a/pkg/kapis/virtualization/v1/validation.go
+++ b/pkg/kapis/virtualization/v1/validation.go
@@ -114,7 +114,7 @@ func isValidGPURequest(gpus []ui_virtz.GPU, resp *restful.Response) bool {
 			}
 			// DeviceName, e.g. "nvidia.com/GRID_A100D-40C"
 			errMsg := k8svalidation.IsQualifiedName(gpu.DeviceName) // Has built-in length check
-			if len(errMsg) > 0 { // TODO test effect
+			if len(errMsg) > 0 {
 				errorReason := "Invalid DeviceName: '" + gpu.DeviceName + "'"
 				for _, msg := range errMsg {
 					errorReason += ", " + msg
@@ -125,14 +125,8 @@ func isValidGPURequest(gpus []ui_virtz.GPU, resp *restful.Response) bool {
 				return false
 			}
 			// VGPUDisplay
-			if gpu.VGPUDisplay == nil {
-				*gpu.VGPUDisplay = true
-			}
 			// VGPURamFB
-			if gpu.VGPURamFB == nil {
-				*gpu.VGPURamFB = true
-			}
-			if *gpu.VGPURamFB {
+			if gpu.VGPURamFB == nil || *gpu.VGPURamFB {
 				if !primaryGPU {
 					primaryGPU = true
 				} else {

--- a/pkg/kapis/virtualization/v1/validation.go
+++ b/pkg/kapis/virtualization/v1/validation.go
@@ -84,14 +84,14 @@ func isValidVirtualMachine(h *virtzhandler, vm ui_virtz.VirtualMachineRequest, r
 		return false
 	}
 
-	if !isValidGPURequest(h, vm.GPUs, resp) {
+	if !isValidGPURequest(h, vm.GPUs, "", "", resp) {
 		return false
 	}
 
 	return true
 }
 
-func isValidGPURequest(h *virtzhandler, gpuRequest *ui_virtz.GPU, resp *restful.Response) bool {
+func isValidGPURequest(h *virtzhandler, gpuRequest *ui_virtz.GPU, namespace string, name string, resp *restful.Response) bool {
 	if gpuRequest != nil {
 		// Quantity, check first, quantity <= 0 is equal to not using any GPU, which will be ignored.
 		if gpuRequest.Quantity <= 0 {
@@ -111,7 +111,7 @@ func isValidGPURequest(h *virtzhandler, gpuRequest *ui_virtz.GPU, resp *restful.
 			return false
 		}
 
-		availableGPUs, err := h.virtz.ListAvailableGPUs()
+		availableGPUs, err := h.virtz.ListAvailableGPUs(namespace, name)
 		if err != nil {
 			resp.WriteHeaderAndEntity(http.StatusBadRequest, util.BadRequestError{
 				Reason: "Invalid request: can't find available GPUs",
@@ -141,7 +141,7 @@ func isValidGPURequest(h *virtzhandler, gpuRequest *ui_virtz.GPU, resp *restful.
 	return true
 }
 
-func isValidModifyVirtualMachine(h *virtzhandler, vm ui_virtz.ModifyVirtualMachineRequest, resp *restful.Response) bool {
+func isValidModifyVirtualMachine(h *virtzhandler, vm ui_virtz.ModifyVirtualMachineRequest, namespace string, id string, resp *restful.Response) bool {
 
 	reflectType := reflect.TypeOf(vm)
 	if !util.IsValidLength(reflectType, vm.Name, "Name", resp) {
@@ -172,7 +172,7 @@ func isValidModifyVirtualMachine(h *virtzhandler, vm ui_virtz.ModifyVirtualMachi
 		}
 	}
 
-	if !isValidGPURequest(h, vm.GPUs, resp) {
+	if !isValidGPURequest(h, vm.GPUs, namespace, id, resp) {
 		return false
 	}
 

--- a/pkg/kapis/virtualization/v1/validation.go
+++ b/pkg/kapis/virtualization/v1/validation.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/emicklei/go-restful"
 	"github.com/minio/minio-go/v7"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	virtzv1alpha1 "kubesphere.io/api/virtualization/v1alpha1"
 
 	"kubesphere.io/kubesphere/pkg/kapis/util"
@@ -47,20 +48,6 @@ func isValidWithinRange(validateType reflect.Type, valueToValidate int, fieldNam
 	}
 	return true
 
-}
-
-func isValidLength(validateType reflect.Type, valueToValidate string, fieldName string, resp *restful.Response) bool {
-	field, found := validateType.FieldByName(fieldName)
-	if found {
-		maximum, _ := strconv.Atoi(field.Tag.Get("maximum"))
-		if len(valueToValidate) > int(maximum) {
-			resp.WriteHeaderAndEntity(http.StatusBadRequest, util.BadRequestError{
-				Reason: fieldName + " length should be less than " + field.Tag.Get("maximum"),
-			})
-			return false
-		}
-	}
-	return true
 }
 
 func isValidString(valueToValidate string, resp *restful.Response) bool {
@@ -97,6 +84,66 @@ func isValidVirtualMachine(vm ui_virtz.VirtualMachineRequest, resp *restful.Resp
 		return false
 	}
 
+	if !isValidGPURequest(vm.GPUs, resp) {
+		return false
+	}
+
+	return true
+}
+
+func isValidGPURequest(gpus []ui_virtz.GPU, resp *restful.Response) bool {
+	if gpus != nil {
+		primaryGPU := false
+		nameMap := make(map[string]bool, 0)
+		reflectType := reflect.TypeOf(ui_virtz.GPU{})
+		for _, gpu := range gpus {
+			// Name
+			if !util.IsValidCaseInsensitiveString(gpu.Name, resp) {
+				return false
+			}
+			if !util.IsValidLength(reflectType, gpu.Name, "Name", resp) {
+				return false
+			}
+			if _, ok := nameMap[gpu.Name]; ok {
+				resp.WriteHeaderAndEntity(http.StatusBadRequest, util.BadRequestError{
+					Reason: "GPU identification name cannot duplicate",
+				})
+				return false
+			} else {
+				nameMap[gpu.Name] = true
+			}
+			// DeviceName, e.g. "nvidia.com/GRID_A100D-40C"
+			errMsg := k8svalidation.IsQualifiedName(gpu.DeviceName) // Has built-in length check
+			if len(errMsg) > 0 { // TODO test effect
+				errorReason := "Invalid DeviceName: '" + gpu.DeviceName + "'"
+				for _, msg := range errMsg {
+					errorReason += ", " + msg
+				}
+				resp.WriteHeaderAndEntity(http.StatusBadRequest, util.BadRequestError{
+					Reason: errorReason,
+				})
+				return false
+			}
+			// VGPUDisplay
+			if gpu.VGPUDisplay == nil {
+				*gpu.VGPUDisplay = true
+			}
+			// VGPURamFB
+			if gpu.VGPURamFB == nil {
+				*gpu.VGPURamFB = true
+			}
+			if *gpu.VGPURamFB {
+				if !primaryGPU {
+					primaryGPU = true
+				} else {
+					resp.WriteHeaderAndEntity(http.StatusBadRequest, util.BadRequestError{
+						Reason: "Only one GPU can enable VGPURamFB setting",
+					})
+					return false
+				}
+			}
+		}
+	}
 	return true
 }
 
@@ -129,6 +176,10 @@ func isValidModifyVirtualMachine(vm ui_virtz.ModifyVirtualMachineRequest, resp *
 		if !isValidWithinRange(reflectType, int(vm.Memory), "Memory", resp) {
 			return false
 		}
+	}
+
+	if !isValidGPURequest(vm.GPUs, resp) {
+		return false
 	}
 
 	if vm.Disk != nil {

--- a/pkg/kapis/virtualization/v1/validation.go
+++ b/pkg/kapis/virtualization/v1/validation.go
@@ -260,12 +260,21 @@ func isValidImageRequest(image ui_virtz.ImageRequest, resp *restful.Response) bo
 		return false
 	}
 
-	if !isValidWithinRange(reflectType, int(image.Size), "Size", resp) {
+	if !isValidOSFamily(image.OSFamily, resp) {
 		return false
 	}
 
-	if !isValidOSFamily(image.OSFamily, resp) {
-		return false
+	if strings.ToLower(image.OSFamily) == "windows" {
+		if int(image.Size) < 90 {
+			resp.WriteHeaderAndEntity(http.StatusForbidden, util.BadRequestError{
+				Reason: "Size of Windows image should be no less then 90Gi",
+			})
+			return false
+		}
+	} else {
+		if !isValidWithinRange(reflectType, int(image.Size), "Size", resp) {
+			return false
+		}
 	}
 
 	if !isValidImageType(image.Type, resp) {

--- a/pkg/kapis/virtualization/v1/validation.go
+++ b/pkg/kapis/virtualization/v1/validation.go
@@ -329,16 +329,10 @@ func isValidModifyImageRequest(image ui_virtz.ModifyImageRequest, resp *restful.
 		}
 	}
 
-	if image.Size != 0 {
-		if !isValidWithinRange(reflectType, int(image.Size), "Size", resp) {
-			return false
-		}
-	}
-
 	return true
 }
 
-func isValidImageSize(h *virtzhandler, namespace string, imageName string, newImageSize int, resp *restful.Response) bool {
+func isValidImageSize(h *virtzhandler, namespace string, imageName string, newImageSize int, request ui_virtz.ModifyImageRequest, resp *restful.Response) bool {
 	image, err := h.virtz.GetImage(namespace, imageName)
 	if err != nil {
 		resp.WriteError(http.StatusInternalServerError, err)
@@ -346,13 +340,24 @@ func isValidImageSize(h *virtzhandler, namespace string, imageName string, newIm
 	}
 
 	oldImageSize, _ := strconv.ParseUint(image.Labels[virtzv1alpha1.VirtualizationImageStorage], 10, 32)
+	osFamily := strings.ToLower(image.Labels[virtzv1alpha1.VirtualizationOSFamily])
+	reflectType := reflect.TypeOf(request)
 	if int(oldImageSize) >= newImageSize {
 		resp.WriteHeaderAndEntity(http.StatusForbidden, util.BadRequestError{
 			Reason: "The new image size must be larger than the old image size",
 		})
 		return false
+	} else if osFamily == "windows" {
+		if newImageSize < 90 {
+			resp.WriteHeaderAndEntity(http.StatusForbidden, util.BadRequestError{
+				Reason: "Size of Windows image should be >= 90 GB",
+			})
+			return false
+		}
+		return true
+	} else {
+		return isValidWithinRange(reflectType, newImageSize, "Size", resp)
 	}
-	return true
 }
 
 func isValidDiskSize(h *virtzhandler, namespace string, diskName string, newDiskSize int, resp *restful.Response) bool {

--- a/pkg/kapis/virtualization/v1/validation.go
+++ b/pkg/kapis/virtualization/v1/validation.go
@@ -267,7 +267,7 @@ func isValidImageRequest(image ui_virtz.ImageRequest, resp *restful.Response) bo
 	if strings.ToLower(image.OSFamily) == "windows" {
 		if int(image.Size) < 90 {
 			resp.WriteHeaderAndEntity(http.StatusForbidden, util.BadRequestError{
-				Reason: "Size of Windows image should be no less then 90Gi",
+				Reason: "Size of Windows image should be >= 90 GB",
 			})
 			return false
 		}

--- a/pkg/models/virtualization/types.go
+++ b/pkg/models/virtualization/types.go
@@ -118,6 +118,15 @@ type ListVirtualMachineResponse struct {
 	Items      []VirtualMachineResponse `json:"items" description:"List of virtual machines"`
 }
 
+type ListAvailableGPUResponse struct {
+	TotalCount int               `json:"total_count" description:"Total number of available GPUs on the cluster."`
+	Items      []GPUNameResponse `json:"items" description:"List of available GPUs on the cluster."`
+}
+
+type GPUNameResponse struct {
+	DeviceName string `json:"deviceName" description:"DeviceName of available GPU."`
+}
+
 // Disk
 type DiskRequest struct {
 	Name        string `json:"name" description:"Disk name. Valid characters: A-Z, a-z, 0-9, and -(hyphen)." maximum:"16"`

--- a/pkg/models/virtualization/types.go
+++ b/pkg/models/virtualization/types.go
@@ -17,7 +17,7 @@ type VirtualMachineRequest struct {
 	Name         string             `json:"name" description:"Virtual machine name. Valid characters: A-Z, a-z, 0-9, and -(hyphen)." maximum:"16"`
 	CpuCores     uint               `json:"cpu_cores" default:"1" description:"Virtual machine cpu cores" minimum:"1" maximum:"4"`
 	Memory       uint               `json:"memory" default:"1" description:"Virtual machine memory size, unit is GB" minimum:"1" maximum:"8"`
-	GPUs         []GPU              `json:"gpus,omitempty" description:"Specify the GPU device(s) to be attached to the virtual machine."`
+	GPUs         *GPU               `json:"gpus,omitempty" description:"Specify the GPU device(s) to be attached to the virtual machine."`
 	Description  string             `json:"description" description:"Virtual machine description. Default is empty string." maximum:"128"`
 	Image        *ImageInfoResponse `json:"image" description:"Virtual machine image source"`
 	Disk         []DiskSpec         `json:"disk,omitempty" description:"Virtual machine disks"`
@@ -27,10 +27,8 @@ type VirtualMachineRequest struct {
 }
 
 type GPU struct {
-	Name        string `json:"name" description:"Identification name of the GPU device. Valid characters: A-Z, a-z, 0-9, and -(hyphen). And must start and end with alphanumeric character." maximum:"32"`
-	DeviceName  string `json:"deviceName" description:"System name of the GPU device. Valid characters: A-Z, a-z, 0-9, /(slash), _(underscore), and -(hyphen). And must start and end with alphanumeric character." maximum:"317"`
-	VGPUDisplay *bool  `json:"vGPUDisplay,omitempty" default:"true" description:"Enables determines if a display addapter backed by a vGPU should be enabled or disabled on the virtual machine."`
-	VGPURamFB   *bool  `json:"vGPURamFB,omitempty" default:"true" description:"Enables a boot framebuffer, until the virtual machine's OS loads a real GPU driver."`
+	Model    string `json:"model" description:"GPU model to be used on this virtual machine. Valid characters: A-Z, a-z, 0-9, /(slash), _(underscore), and -(hyphen). And must start and end with alphanumeric character." maximum:"317"`
+	Quantity int    `json:"quantity" description:"GPU quantity to be used on this virtual machine. Must not exceed maximum available GPUs." minimum:"0"`
 }
 
 type DiskSpec struct {
@@ -65,7 +63,7 @@ type ModifyVirtualMachineRequest struct {
 	Name         string           `json:"name,omitempty" description:"Virtual machine name. Valid characters: A-Z, a-z, 0-9, and -(hyphen)." maximum:"16"`
 	CpuCores     uint             `json:"cpu_cores,omitempty" default:"1" description:"Virtual machine cpu cores." minimum:"1" maximum:"4"`
 	Memory       uint             `json:"memory,omitempty" default:"1" description:"Virtual machine memory size, unit is GB." minimum:"1" maximum:"8"`
-	GPUs         []GPU            `json:"gpus,omitempty" description:"Specify the GPU device(s) to be attached to the virtual machine."`
+	GPUs         *GPU             `json:"gpus,omitempty" description:"Specify the GPU device(s) to be attached to the virtual machine."`
 	Disk         []ModifyDiskSpec `json:"disk,omitempty" description:"Virtual machine disks"`
 	Description  *string          `json:"description,omitempty" description:"Virtual machine description. Can be empty string." maximum:"128"`
 	Labels       []Label          `json:"labels,omitempty" description:"Virtual machine labels. Can be empty array."`
@@ -79,7 +77,7 @@ type VirtualMachineResponse struct {
 	Description  string             `json:"description" description:"Virtual machine description"`
 	CpuCores     uint               `json:"cpu_cores" description:"Virtual machine cpu cores"`
 	Memory       uint               `json:"memory" description:"Virtual machine memory size"`
-	GPUs         []GPUResponse      `json:"gpus" description:"Specify the GPU device(s) to be attached to the virtual machine."`
+	GPUs         GPUResponse        `json:"gpus" description:"Specify the GPU device(s) to be attached to the virtual machine."`
 	Image        *ImageInfoResponse `json:"image" description:"Virtual machine image source"`
 	Disks        []DiskResponse     `json:"disks" description:"Virtual machine disks"`
 	Status       VMStatus           `json:"status" description:"Virtual machine status"`
@@ -94,10 +92,8 @@ type VirtualMachineIDResponse struct {
 }
 
 type GPUResponse struct {
-	Name        string `json:"name" description:"Identification name of the GPU device."`
-	DeviceName  string `json:"deviceName" description:"System name of the GPU device."`
-	VGPUDisplay bool   `json:"vGPUDisplay" description:"Enables determines if a display addapter backed by a vGPU should be enabled or disabled on the virtual machine."`
-	VGPURamFB   bool   `json:"vGPURamFB" description:"Enables a boot framebuffer, until the virtual machine's OS loads a real GPU driver."`
+	Model    string `json:"model" description:"GPU model to be used on this virtual machine."`
+	Quantity int    `json:"quantity" description:"GPU quantity to be used on this virtual machine."`
 }
 
 type ImageIDResponse struct {
@@ -119,12 +115,13 @@ type ListVirtualMachineResponse struct {
 }
 
 type ListAvailableGPUResponse struct {
-	TotalCount int               `json:"total_count" description:"Total number of available GPUs on the cluster."`
-	Items      []GPUNameResponse `json:"items" description:"List of available GPUs on the cluster."`
+	TotalCount int                   `json:"total_count" description:"Total number of available GPUs on the cluster."`
+	Items      []GPUResourceResponse `json:"items" description:"List of available GPUs on the cluster."`
 }
 
-type GPUNameResponse struct {
-	DeviceName string `json:"deviceName" description:"DeviceName of available GPU."`
+type GPUResourceResponse struct {
+	Model    string `json:"model" description:"Model of available GPU."`
+	Quantity int    `json:"quantity" description:"Quantity of available GPU."`
 }
 
 // Disk

--- a/pkg/models/virtualization/types.go
+++ b/pkg/models/virtualization/types.go
@@ -17,12 +17,20 @@ type VirtualMachineRequest struct {
 	Name         string             `json:"name" description:"Virtual machine name. Valid characters: A-Z, a-z, 0-9, and -(hyphen)." maximum:"16"`
 	CpuCores     uint               `json:"cpu_cores" default:"1" description:"Virtual machine cpu cores" minimum:"1" maximum:"4"`
 	Memory       uint               `json:"memory" default:"1" description:"Virtual machine memory size, unit is GB" minimum:"1" maximum:"8"`
+	GPUs         []GPU              `json:"gpus,omitempty" description:"Specify the GPU device(s) to be attached to the virtual machine."`
 	Description  string             `json:"description" description:"Virtual machine description. Default is empty string." maximum:"128"`
 	Image        *ImageInfoResponse `json:"image" description:"Virtual machine image source"`
 	Disk         []DiskSpec         `json:"disk,omitempty" description:"Virtual machine disks"`
 	Guest        *GuestSpec         `json:"guest,omitempty" description:"Virtual machine guest operating system"`
 	Labels       []Label            `json:"labels,omitempty" description:"Virtual machine labels"`
 	NodeSelector []NodeSelector     `json:"node_selector,omitempty" description:"Virtual machine node selector"`
+}
+
+type GPU struct {
+	Name        string `json:"name" description:"Identification name of the GPU device. Valid characters: A-Z, a-z, 0-9, and -(hyphen). And must start and end with alphanumeric character." maximum:"32"`
+	DeviceName  string `json:"deviceName" description:"System name of the GPU device. Valid characters: A-Z, a-z, 0-9, /(slash), _(underscore), and -(hyphen). And must start and end with alphanumeric character." maximum:"317"`
+	VGPUDisplay *bool  `json:"vGPUDisplay,omitempty" default:"true" description:"Enables determines if a display addapter backed by a vGPU should be enabled or disabled on the virtual machine."`
+	VGPURamFB   *bool  `json:"vGPURamFB,omitempty" default:"true" description:"Enables a boot framebuffer, until the virtual machine's OS loads a real GPU driver."`
 }
 
 type DiskSpec struct {
@@ -57,6 +65,7 @@ type ModifyVirtualMachineRequest struct {
 	Name         string           `json:"name,omitempty" description:"Virtual machine name. Valid characters: A-Z, a-z, 0-9, and -(hyphen)." maximum:"16"`
 	CpuCores     uint             `json:"cpu_cores,omitempty" default:"1" description:"Virtual machine cpu cores." minimum:"1" maximum:"4"`
 	Memory       uint             `json:"memory,omitempty" default:"1" description:"Virtual machine memory size, unit is GB." minimum:"1" maximum:"8"`
+	GPUs         []GPU            `json:"gpus,omitempty" description:"Specify the GPU device(s) to be attached to the virtual machine."`
 	Disk         []ModifyDiskSpec `json:"disk,omitempty" description:"Virtual machine disks"`
 	Description  *string          `json:"description,omitempty" description:"Virtual machine description. Can be empty string." maximum:"128"`
 	Labels       []Label          `json:"labels,omitempty" description:"Virtual machine labels. Can be empty array."`
@@ -70,6 +79,7 @@ type VirtualMachineResponse struct {
 	Description  string             `json:"description" description:"Virtual machine description"`
 	CpuCores     uint               `json:"cpu_cores" description:"Virtual machine cpu cores"`
 	Memory       uint               `json:"memory" description:"Virtual machine memory size"`
+	GPUs         []GPUResponse      `json:"gpus" description:"Specify the GPU device(s) to be attached to the virtual machine."`
 	Image        *ImageInfoResponse `json:"image" description:"Virtual machine image source"`
 	Disks        []DiskResponse     `json:"disks" description:"Virtual machine disks"`
 	Status       VMStatus           `json:"status" description:"Virtual machine status"`
@@ -81,6 +91,13 @@ type VirtualMachineResponse struct {
 
 type VirtualMachineIDResponse struct {
 	ID string `json:"id" description:"virtual machine id"`
+}
+
+type GPUResponse struct {
+	Name        string `json:"name" description:"Identification name of the GPU device."`
+	DeviceName  string `json:"deviceName" description:"System name of the GPU device."`
+	VGPUDisplay bool   `json:"vGPUDisplay" description:"Enables determines if a display addapter backed by a vGPU should be enabled or disabled on the virtual machine."`
+	VGPURamFB   bool   `json:"vGPURamFB" description:"Enables a boot framebuffer, until the virtual machine's OS loads a real GPU driver."`
 }
 
 type ImageIDResponse struct {

--- a/pkg/models/virtualization/types.go
+++ b/pkg/models/virtualization/types.go
@@ -174,7 +174,7 @@ type ImageInfo struct {
 type ImageInfoResponse struct {
 	ID        string `json:"id" description:"Image id which is got from image api"`
 	Namespace string `json:"namespace" description:"Image namespace"`
-	Size      uint   `json:"size" default:"20" description:"Image size, unit is GB." minimum:"10" maximum:"80"`
+	Size      uint   `json:"size" default:"20" description:"Image size, unit is GB. Image size range is 10 ~ 80 GB. For 'windows' images , the default is 90 GB and range is >= 90 GB." minimum:"10" maximum:"80"`
 }
 
 type ImageRequest struct {
@@ -183,7 +183,7 @@ type ImageRequest struct {
 	Version        string `json:"version" default:"20.04_LTS_64bit" description:"Image version"`
 	CpuCores       uint   `json:"cpu_cores" default:"1" description:"Default image cpu cores" minimum:"1" maximum:"4"`
 	Memory         uint   `json:"memory" default:"1" description:"Default image memory, unit is GB." minimum:"1" maximum:"8"`
-	Size           uint   `json:"size" default:"20" description:"Default image size, unit is GB." minimum:"10" maximum:"80"`
+	Size           uint   `json:"size" default:"20" description:"Default image size, unit is GB. Image size range is 10 ~ 80 GB. If os_family is 'windows', the default is 90 GB and range is >= 90 GB." minimum:"10" maximum:"80"`
 	Description    string `json:"description" description:"Image description. Default is empty string." maximum:"128"`
 	MinioImageName string `json:"minio_image_name" description:"File name which created by minio image api"`
 	Shared         bool   `json:"shared" default:"false" description:"Image shared or not"`
@@ -200,7 +200,7 @@ type ModifyImageRequest struct {
 	Name        string  `json:"name,omitempty" description:"Image name. Valid characters: A-Z, a-z, 0-9, and -(hyphen)." maximum:"16"`
 	CpuCores    uint    `json:"cpu_cores,omitempty" default:"1" description:"Default image cpu cores" minimum:"1" maximum:"4"`
 	Memory      uint    `json:"memory,omitempty" default:"1" description:"Default image memory, unit is GB." minimum:"1" maximum:"8"`
-	Size        uint    `json:"size,omitempty" default:"20" description:"Default image size, unit is GB and the size only can be increased." minimum:"10" maximum:"80"`
+	Size        uint    `json:"size,omitempty" default:"20" description:"Default image size, unit is GB and the size only can be increased. For 'windows' images, the default is 90 GB and range is >= 90 GB." minimum:"10" maximum:"80"`
 	Description *string `json:"description,omitempty" default:"" description:"Image description. Can be empty string." maximum:"128"`
 	Shared      bool    `json:"shared,omitempty" default:"false" description:"Image shared or not"`
 }
@@ -213,7 +213,7 @@ type ImageResponse struct {
 	Version        string      `json:"version" default:"20.04_LTS_64bit" description:"Image version"`
 	CpuCores       uint        `json:"cpu_cores" default:"1" description:"Default image cpu cores" minimum:"1" maximum:"4"`
 	Memory         uint        `json:"memory" default:"1" description:"Default image memory, unit is GB" minimum:"1" maximum:"8"`
-	Size           uint        `json:"size" default:"20" description:"Default image size, unit is GB" minimum:"10" maximum:"80"`
+	Size           uint        `json:"size" default:"20" description:"Default image size, unit is GB. If os_family is 'windows', the default is 90 GB and range is >= 90 GB." minimum:"10" maximum:"80"`
 	MinioImageName string      `json:"minio_image_name" description:"File name which created by minio image api"`
 	Description    string      `json:"description" default:"" description:"Image description"`
 	Shared         bool        `json:"shared" default:"false" description:"Image shared or not"`

--- a/pkg/models/virtualization/virtualization.go
+++ b/pkg/models/virtualization/virtualization.go
@@ -41,6 +41,7 @@ type Interface interface {
 	StopVirtualMachine(namespace string, name string) (*v1alpha1.VirtualMachine, error)
 	ListVirtualMachine(namespace string) (*v1alpha1.VirtualMachineList, error)
 	DeleteVirtualMachine(namespace string, name string) (*v1alpha1.VirtualMachine, error)
+	ListAvailableGPUs() ([]GPUResourceResponse, error)
 	// Disk
 	CreateDisk(namespace string, ui_disk *DiskRequest) (*v1alpha1.DiskVolume, error)
 	UpdateDisk(namespace string, name string, ui_disk *ModifyDiskRequest) (*v1alpha1.DiskVolume, error)
@@ -616,30 +617,24 @@ func ConvertLabelToMap(array interface{}) map[string]string {
 	return returnMap
 }
 
-func ConvertGPUsToSpec(gpus []GPU) []kvapi.GPU {
+func ConvertGPUsToSpec(requestGPU *GPU) []kvapi.GPU {
 	returnArray := make([]kvapi.GPU, 0)
-	for _, gpu := range gpus {
-		if gpu.VGPUDisplay == nil {
-			gpu.VGPUDisplay = new(bool)
-			*gpu.VGPUDisplay = true
+	if requestGPU != nil {
+		for idx := 0; idx < requestGPU.Quantity; idx++ {
+			spec := kvapi.GPU{
+				Name:       "gpu" + strconv.Itoa(idx), // gpu0, gpu1, ...
+				DeviceName: requestGPU.Model,
+				//VirtualGPUOptions: &kvapi.VGPUOptions{
+				//	Display: &kvapi.VGPUDisplayOptions{
+				//		Enabled: true,
+				//		RamFB: &kvapi.FeatureState{
+				//			Enabled: true,
+				//		},
+				//	},
+				//},
+			}
+			returnArray = append(returnArray, spec)
 		}
-		if gpu.VGPURamFB == nil {
-			gpu.VGPURamFB = new(bool)
-			*gpu.VGPURamFB = true
-		}
-		spec := kvapi.GPU{
-			Name:       gpu.Name,
-			DeviceName: gpu.DeviceName,
-			VirtualGPUOptions: &kvapi.VGPUOptions{
-				Display: &kvapi.VGPUDisplayOptions{
-					Enabled: gpu.VGPUDisplay,
-					RamFB: &kvapi.FeatureState{
-						Enabled: gpu.VGPURamFB,
-					},
-				},
-			},
-		}
-		returnArray = append(returnArray, spec)
 	}
 	return returnArray
 }
@@ -864,6 +859,30 @@ func (v *virtualizationOperator) DeleteVirtualMachine(namespace string, name str
 	}
 
 	return vm, nil
+}
+
+func (v *virtualizationOperator) ListAvailableGPUs() ([]GPUResourceResponse, error) {
+	availableGPUs := make([]GPUResourceResponse, 0)
+	nodes, err := v.k8sclient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for _, node := range nodes.Items {
+		allocatable := node.Status.Allocatable
+		for key, value := range allocatable {
+			if strings.Contains(key.String(), "gpu/") {
+				if quantity, flag := value.AsInt64();flag && quantity > 0 {
+					response := GPUResourceResponse{
+						Model:    key.String(),
+						Quantity: int(quantity),
+					}
+					availableGPUs = append(availableGPUs, response)
+				}
+			}
+		}
+	}
+
+	return availableGPUs, nil
 }
 
 func (v *virtualizationOperator) GetDisk(namespace string, name string) (*v1alpha1.DiskVolume, error) {

--- a/pkg/models/virtualization/virtualization.go
+++ b/pkg/models/virtualization/virtualization.go
@@ -269,6 +269,59 @@ func ApplyCloudImageSpec(ui_vm *VirtualMachineRequest, vm *v1alpha1.VirtualMachi
 		},
 	}
 
+	osFamily := imagetemplate.Labels[v1alpha1.VirtualizationOSFamily]
+	if strings.ToLower(osFamily) == "windows" {
+		// Add extra settings for Windows VM
+		var falseFlag bool = false
+		vm.Spec.Hardware.Domain.Clock = &kvapi.Clock{
+			Timer: &kvapi.Timer{
+				HPET: &kvapi.HPETTimer{
+					Enabled: &falseFlag,
+				},
+				Hyperv: &kvapi.HypervTimer{},
+				PIT: &kvapi.PITTimer{
+					TickPolicy: "delay",
+				},
+				RTC: &kvapi.RTCTimer{
+					TickPolicy: "catchup",
+				},
+			},
+			ClockOffset: kvapi.ClockOffset{
+				UTC: &kvapi.ClockOffsetUTC{},
+			},
+		}
+
+		var spinlocksRetries uint32 = 8191
+		vm.Spec.Hardware.Domain.Features = &kvapi.Features{
+			ACPI: kvapi.FeatureState{},
+			APIC: &kvapi.FeatureAPIC{},
+			Hyperv: &kvapi.FeatureHyperv{
+				Relaxed: &kvapi.FeatureState{},
+				VAPIC:   &kvapi.FeatureState{},
+				Spinlocks: &kvapi.FeatureSpinlocks{
+					Retries: &spinlocksRetries,
+				},
+			},
+			SMM: &kvapi.FeatureState{},
+		}
+
+		var trueFlag bool = true
+		vm.Spec.Hardware.Domain.Firmware = &kvapi.Firmware{
+			Bootloader: &kvapi.Bootloader{
+				EFI: &kvapi.EFI{
+					SecureBoot: &trueFlag,
+				},
+			},
+		}
+
+		for idx, kvInterface := range vm.Spec.Hardware.Domain.Devices.Interfaces {
+			if kvInterface.Name == "default" {
+				vm.Spec.Hardware.Domain.Devices.Interfaces[idx].Model = "e1000"
+				break; // Only modify default interface's model
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/models/virtualization/virtualization.go
+++ b/pkg/models/virtualization/virtualization.go
@@ -41,7 +41,7 @@ type Interface interface {
 	StopVirtualMachine(namespace string, name string) (*v1alpha1.VirtualMachine, error)
 	ListVirtualMachine(namespace string) (*v1alpha1.VirtualMachineList, error)
 	DeleteVirtualMachine(namespace string, name string) (*v1alpha1.VirtualMachine, error)
-	ListAvailableGPUs() ([]GPUResourceResponse, error)
+	ListAvailableGPUs(namespace string, name string) ([]GPUResourceResponse, error)
 	// Disk
 	CreateDisk(namespace string, ui_disk *DiskRequest) (*v1alpha1.DiskVolume, error)
 	UpdateDisk(namespace string, name string, ui_disk *ModifyDiskRequest) (*v1alpha1.DiskVolume, error)
@@ -861,7 +861,7 @@ func (v *virtualizationOperator) DeleteVirtualMachine(namespace string, name str
 	return vm, nil
 }
 
-func (v *virtualizationOperator) ListAvailableGPUs() ([]GPUResourceResponse, error) {
+func (v *virtualizationOperator) ListAvailableGPUs(namespace string, name string) ([]GPUResourceResponse, error) {
 	// 1. Get all GPU resouces from all nodes to a map
 	gpuResources := make(map[string]int, 0)
 	nodes, err := v.k8sclient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
@@ -889,6 +889,10 @@ func (v *virtualizationOperator) ListAvailableGPUs() ([]GPUResourceResponse, err
 		return nil, err
 	}
 	for _, ksvm := range ksvms.Items {
+		if ksvm.Namespace == namespace && ksvm.Name == name {
+			// When PUT VM, don't subtract allocated GPUs from available GPUs quantity
+			continue;
+		}
 		for _, gpu := range ksvm.Spec.Hardware.Domain.Devices.GPUs {
 			if _, ok := gpuResources[gpu.DeviceName]; ok {
 				gpuResources[gpu.DeviceName] -= 1 // GPU is listed one by one, so subtract 1 each time found in spec

--- a/pkg/models/virtualization/virtualization.go
+++ b/pkg/models/virtualization/virtualization.go
@@ -619,6 +619,14 @@ func ConvertLabelToMap(array interface{}) map[string]string {
 func ConvertGPUsToSpec(gpus []GPU) []kvapi.GPU {
 	returnArray := make([]kvapi.GPU, 0)
 	for _, gpu := range gpus {
+		if gpu.VGPUDisplay == nil {
+			gpu.VGPUDisplay = new(bool)
+			*gpu.VGPUDisplay = true
+		}
+		if gpu.VGPURamFB == nil {
+			gpu.VGPURamFB = new(bool)
+			*gpu.VGPURamFB = true
+		}
 		spec := kvapi.GPU{
 			Name:       gpu.Name,
 			DeviceName: gpu.DeviceName,
@@ -660,7 +668,7 @@ func (v *virtualizationOperator) UpdateVirtualMachine(namespace string, name str
 	}
 
 	if ui_vm.GPUs != nil {
-		vm.Spec.Hardware.Domain.Devices.GPUs = ConvertGPUsToSpec(ui_vm.GPUs) // TODO test empty array
+		vm.Spec.Hardware.Domain.Devices.GPUs = ConvertGPUsToSpec(ui_vm.GPUs)
 	}
 
 	// TODO: update image size

--- a/pkg/models/virtualization/virtualization.go
+++ b/pkg/models/virtualization/virtualization.go
@@ -862,7 +862,8 @@ func (v *virtualizationOperator) DeleteVirtualMachine(namespace string, name str
 }
 
 func (v *virtualizationOperator) ListAvailableGPUs() ([]GPUResourceResponse, error) {
-	availableGPUs := make([]GPUResourceResponse, 0)
+	// 1. Get all GPU resouces from all nodes to a map
+	gpuResources := make(map[string]int, 0)
 	nodes, err := v.k8sclient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return nil, err
@@ -872,14 +873,40 @@ func (v *virtualizationOperator) ListAvailableGPUs() ([]GPUResourceResponse, err
 		for key, value := range allocatable {
 			if strings.Contains(key.String(), "gpu/") {
 				if quantity, flag := value.AsInt64();flag && quantity > 0 {
-					response := GPUResourceResponse{
-						Model:    key.String(),
-						Quantity: int(quantity),
+					if _, ok := gpuResources[key.String()]; !ok {
+						gpuResources[key.String()] = int(quantity)
+					} else {
+						gpuResources[key.String()] += int(quantity)
 					}
-					availableGPUs = append(availableGPUs, response)
 				}
 			}
 		}
+	}
+
+	// 2. Subtract allocated GPU resources from the map
+	ksvms, err := v.ksclient.VirtualizationV1alpha1().VirtualMachines(metav1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for _, ksvm := range ksvms.Items {
+		for _, gpu := range ksvm.Spec.Hardware.Domain.Devices.GPUs {
+			if _, ok := gpuResources[gpu.DeviceName]; ok {
+				gpuResources[gpu.DeviceName] -= 1 // GPU is listed one by one, so subtract 1 each time found in spec
+			}
+		}
+	}
+
+	// 3. Make []GPUResourceResponse from the map
+	availableGPUs := make([]GPUResourceResponse, 0)
+	for key, quantity := range gpuResources {
+		if quantity <= 0 {
+			continue
+		}
+		response := GPUResourceResponse{
+			Model:    key,
+			Quantity: int(quantity),
+		}
+		availableGPUs = append(availableGPUs, response)
 	}
 
 	return availableGPUs, nil

--- a/pkg/models/virtualization/virtualization.go
+++ b/pkg/models/virtualization/virtualization.go
@@ -150,6 +150,7 @@ func ApplyVMSpec(ui_vm *VirtualMachineRequest, vm *v1alpha1.VirtualMachine, vm_u
 					},
 				},
 			},
+			GPUs: ConvertGPUsToSpec(ui_vm.GPUs),
 		},
 		Resources: v1alpha1.ResourceRequirements{
 			Requests: v1.ResourceList{
@@ -615,6 +616,26 @@ func ConvertLabelToMap(array interface{}) map[string]string {
 	return returnMap
 }
 
+func ConvertGPUsToSpec(gpus []GPU) []kvapi.GPU {
+	returnArray := make([]kvapi.GPU, 0)
+	for _, gpu := range gpus {
+		spec := kvapi.GPU{
+			Name:       gpu.Name,
+			DeviceName: gpu.DeviceName,
+			VirtualGPUOptions: &kvapi.VGPUOptions{
+				Display: &kvapi.VGPUDisplayOptions{
+					Enabled: gpu.VGPUDisplay,
+					RamFB: &kvapi.FeatureState{
+						Enabled: gpu.VGPURamFB,
+					},
+				},
+			},
+		}
+		returnArray = append(returnArray, spec)
+	}
+	return returnArray
+}
+
 func (v *virtualizationOperator) UpdateVirtualMachine(namespace string, name string, ui_vm *ModifyVirtualMachineRequest) (*v1alpha1.VirtualMachine, error) {
 	vm, err := v.ksclient.VirtualizationV1alpha1().VirtualMachines(namespace).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
@@ -636,6 +657,10 @@ func (v *virtualizationOperator) UpdateVirtualMachine(namespace string, name str
 	if ui_vm.Memory != 0 && ui_vm.Memory != uint(vm.Spec.Hardware.Domain.Resources.Requests.Memory().Size()) {
 		vm.Spec.Hardware.Domain.Resources.Requests[v1.ResourceMemory] =
 			resource.MustParse(strconv.FormatUint(uint64(ui_vm.Memory), 10) + "Gi")
+	}
+
+	if ui_vm.GPUs != nil {
+		vm.Spec.Hardware.Domain.Devices.GPUs = ConvertGPUsToSpec(ui_vm.GPUs) // TODO test empty array
 	}
 
 	// TODO: update image size

--- a/staging/src/kubesphere.io/api/virtualization/v1alpha1/virtualmachine_types.go
+++ b/staging/src/kubesphere.io/api/virtualization/v1alpha1/virtualmachine_types.go
@@ -60,6 +60,12 @@ type DomainSpec struct {
 	// Machine type.
 	// +optional
 	Machine *kvapi.Machine `json:"machine,omitempty"`
+	// Firmware.
+	// +optional
+	Firmware *kvapi.Firmware `json:"firmware,omitempty"`
+	// Clock sets the clock and timers of the vmi.
+	// +optional
+	Clock *kvapi.Clock `json:"clock,omitempty"`
 	// Features like acpi, apic, hyperv, smm.
 	// +optional
 	Features *kvapi.Features `json:"features,omitempty"`

--- a/staging/src/kubesphere.io/api/virtualization/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/kubesphere.io/api/virtualization/v1alpha1/zz_generated.deepcopy.go
@@ -206,6 +206,16 @@ func (in *DomainSpec) DeepCopyInto(out *DomainSpec) {
 		*out = new(v1.Machine)
 		**out = **in
 	}
+	if in.Firmware != nil {
+		in, out := &in.Firmware, &out.Firmware
+		*out = new(v1.Firmware)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Clock != nil {
+		in, out := &in.Clock, &out.Clock
+		*out = new(v1.Clock)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Features != nil {
 		in, out := &in.Features, &out.Features
 		*out = new(v1.Features)


### PR DESCRIPTION
Adds support to GPU options for VM, and supports Windows VM:
- Adds GPU options to POST/PUT VM APIs
- Adds allocated GPU model and quantity to GET VM APIs
- Adds GET gpus API, but only for VM pages
- Changes virtual machine controller action to put GPU options onto KVVM
- Adds necessary settings to Windows VM's KSVM
- Changes image APIs to set enough disk space
- Changes image APIs' validation logic
- Changes boot disk type for Windows VM to boot