### PR TITLE
Add MARS DSCP K8s controller

### DIFF
--- a/cmd/controller-manager/app/controllers.go
+++ b/cmd/controller-manager/app/controllers.go
@@ -32,6 +32,7 @@ import (
 
 	"kubesphere.io/kubesphere/cmd/controller-manager/app/options"
 	"kubesphere.io/kubesphere/pkg/controller/application"
+	"kubesphere.io/kubesphere/pkg/controller/dscp"
 	"kubesphere.io/kubesphere/pkg/controller/helm"
 	"kubesphere.io/kubesphere/pkg/controller/namespace"
 	"kubesphere.io/kubesphere/pkg/controller/openpitrix/helmapplication"
@@ -126,6 +127,7 @@ var allControllers = []string{
 	"virtualmachine",
 	"diskvolume",
 	"imagetemplate",
+	"dscp",
 }
 
 // setup all available controllers one by one
@@ -563,6 +565,15 @@ func addAllControllers(mgr manager.Manager, client k8s.Client, informerFactory i
 	if cmOptions.IsControllerEnabled("imagetemplate") {
 		imageTemplateReconciler := &imagetemplate.Reconciler{}
 		addControllerWithSetup(mgr, "imagetemplate", imageTemplateReconciler)
+	}
+
+	// "dscp" controller
+	if cmOptions.IsControllerEnabled("dscp") {
+		dscpController := dscp.NewDscpController(client.Kubernetes(),
+			kubernetesInformer.Core().V1().ConfigMaps(),
+			kubernetesInformer.Apps().V1().DaemonSets(),
+			kubernetesInformer.Core().V1().Pods())
+		addController(mgr, "dscp", dscpController)
 	}
 
 	// log all controllers process result

--- a/pkg/controller/dscp/dscp_controller.go
+++ b/pkg/controller/dscp/dscp_controller.go
@@ -40,7 +40,7 @@ import (
 const (
 	appName = "dscp"
 	controllerName = "dscp-controller"
-	configNamespace = "default"
+	configNamespace = "kube-system"
 	configName = "k8s-dscp-config"
 	daemonSetName = "k8s-dscp"
 
@@ -54,9 +54,11 @@ type NamespaceDscp struct {
 }
 
 type DscpConfig struct {
+	CNI              string              `yaml:"cni"`
+	ContainerImage   string              `yaml:"container_image"`
 	MARS             map[string]string   `yaml:"mars"`
-	NamespaceDscpMap []NamespaceDscp     `yaml:"namespace_dscp_map"`
 	QueueDscpMap     map[string][]string `yaml:"queue_dscp_map"`
+	NamespaceDscpMap []NamespaceDscp     `yaml:"namespace_dscp_map"`
 }
 
 // Controller is the controller implementation for Foo resources
@@ -554,7 +556,7 @@ func newDaemonSetFromConfigMap(clientset kubernetes.Interface, dscpConfig DscpCo
 					Containers: []corev1.Container{
 						{
 							Name:  "dscp-container",
-							Image: "iptables",
+							Image: dscpConfig.ContainerImage,
 							Command: []string{"sh", "-c"},
 							Args: generateIptablesDscpCommand(dscpIpMap, false),
 							ImagePullPolicy: corev1.PullIfNotPresent,

--- a/pkg/controller/dscp/dscp_controller.go
+++ b/pkg/controller/dscp/dscp_controller.go
@@ -1,0 +1,727 @@
+package dscp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+	"strconv"
+	"time"
+	"gopkg.in/yaml.v3"
+
+	corev1informer "k8s.io/client-go/informers/core/v1"
+	appsv1informer "k8s.io/client-go/informers/apps/v1"
+	typedcorev1  "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1lister "k8s.io/client-go/listers/core/v1"
+	appsv1lister "k8s.io/client-go/listers/apps/v1"
+	"k8s.io/klog"
+
+	corev1 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/client-go/util/workqueue"
+)
+
+const (
+	appName = "dscp"
+	controllerName = "dscp-controller"
+	configNamespace = "default"
+	configName = "k8s-dscp-config"
+	daemonSetName = "k8s-dscp"
+
+	// DSCP ConfigMap yaml data
+	configMapYamlData = "k8s_dscp_config.yaml"
+)
+
+type NamespaceDscp struct {
+	Name string `yaml:"name"`
+	DSCP string `yaml:"dscp"`
+}
+
+type DscpConfig struct {
+	MARS             map[string]string   `yaml:"mars"`
+	NamespaceDscpMap []NamespaceDscp     `yaml:"namespace_dscp_map"`
+	QueueDscpMap     map[string][]string `yaml:"queue_dscp_map"`
+}
+
+// Controller is the controller implementation for Foo resources
+type Controller struct {
+	// kubeclientset is a standard kubernetes clientset
+	kubeclientset kubernetes.Interface
+
+	configMapLister corev1lister.ConfigMapLister
+	configMapsSynced cache.InformerSynced
+
+	daemonSetLister appsv1lister.DaemonSetLister
+	daemonSetsSynced cache.InformerSynced
+
+	podLister  corev1lister.PodLister
+	podsSynced cache.InformerSynced
+
+	// workqueue is a rate limited work queue. This is used to queue work to be
+	// processed instead of performing it as soon as a change happens. This
+	// means we can ensure we only process a fixed amount of resources at a
+	// time, and makes it easy to ensure we are never processing the same item
+	// simultaneously in two different workers.
+	workqueue workqueue.RateLimitingInterface
+	// recorder is an event recorder for recording Event resources to the
+	// Kubernetes API.
+	recorder record.EventRecorder
+}
+
+// NewController returns a new sample controller
+func NewDscpController(
+	kubeclientset kubernetes.Interface,
+	configMapInformer corev1informer.ConfigMapInformer,
+	daemonSetInformer appsv1informer.DaemonSetInformer,
+	podInformer corev1informer.PodInformer) *Controller {
+
+	klog.V(4).Info("Creating event broadcaster")
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(klog.Infof)
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeclientset.CoreV1().Events("")})
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerName})
+
+	controller := &Controller{
+		kubeclientset:    kubeclientset,
+		configMapLister:  configMapInformer.Lister(),
+		configMapsSynced: configMapInformer.Informer().HasSynced,
+		daemonSetLister:  daemonSetInformer.Lister(),
+		daemonSetsSynced: daemonSetInformer.Informer().HasSynced,
+		podLister:        podInformer.Lister(),
+		podsSynced:       podInformer.Informer().HasSynced,
+		workqueue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), appName),
+		recorder:         recorder,
+	}
+
+	klog.Info("Setting up event handlers")
+
+	configMapInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    controller.enqueueConfigMap,
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldCm := oldObj.(*corev1.ConfigMap)
+			newCm := newObj.(*corev1.ConfigMap)
+
+			if reflect.DeepEqual(oldCm.Data, newCm.Data) {
+				return // ConfigMap內容沒變就不進入 enqueue function
+			}
+			controller.enqueueConfigMap(newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+			if ok {
+				controller.enqueueConfigMap(tombstone.Obj)
+				return
+			}
+			controller.enqueueConfigMap(obj)
+		},
+	})
+
+	daemonSetInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    controller.enqueueDaemonSet,
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			controller.enqueueDaemonSet(newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+			if ok {
+				controller.enqueueDaemonSet(tombstone.Obj)
+				return
+			}
+			controller.enqueueDaemonSet(obj)
+		},
+	})
+
+	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: controller.handlePodUpdate,
+		DeleteFunc: controller.handlePodDelete,
+	})
+
+	return controller
+}
+
+func (c *Controller) Start(ctx context.Context) error {
+	return c.Run(1, ctx.Done())
+}
+
+// Run will set up the event handlers for types we are interested in, as well
+// as syncing informer caches and starting workers. It will block until stopCh
+// is closed, at which point it will shutdown the workqueue and wait for
+// workers to finish processing their current work items.
+func (c *Controller) Run(workers int, stopCh <-chan struct{}) error {
+	defer utilruntime.HandleCrash()
+	defer c.workqueue.ShutDown()
+
+	// Start the informer factories to begin populating the informer caches
+	klog.Info("Starting DSCP client-go controller")
+
+	// Wait for the caches to be synced before starting workers
+	klog.Info("Waiting for informer caches to sync")
+	if ok := cache.WaitForCacheSync(stopCh, c.configMapsSynced, c.daemonSetsSynced); !ok {
+		return fmt.Errorf("Failed to wait for caches to sync")
+	}
+
+	klog.Info("Starting workers")
+	// Launch two workers to process Foo resources
+	for i := 0; i < workers; i++ {
+		go wait.Until(c.runWorker, time.Second, stopCh)
+	}
+
+	klog.Info("Started workers")
+	<-stopCh
+	klog.Info("Shutting down workers")
+
+	return nil
+}
+
+// runWorker is a long-running function that will continually call the
+// processNextWorkItem function in order to read and process a message on the
+// workqueue.
+func (c *Controller) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+// processNextWorkItem will read a single work item off the workqueue and
+// attempt to process it, by calling the syncHandler.
+func (c *Controller) processNextWorkItem() bool {
+	obj, shutdown := c.workqueue.Get()
+
+	if shutdown {
+		return false
+	}
+
+	// We wrap this block in a func so we can defer c.workqueue.Done.
+	err := func(obj interface{}) error {
+		// We call Done here so the workqueue knows we have finished
+		// processing this item. We also must remember to call Forget if we
+		// do not want this work item being re-queued. For example, we do
+		// not call Forget if a transient error occurs, instead the item is
+		// put back on the workqueue and attempted again after a back-off
+		// period.
+		defer c.workqueue.Done(obj)
+		var key string
+		var ok bool
+		// We expect strings to come off the workqueue. These are of the
+		// form namespace/name. We do this as the delayed nature of the
+		// workqueue means the items in the informer cache may actually be
+		// more up to date that when the item was initially put onto the
+		// workqueue.
+		if key, ok = obj.(string); !ok {
+			// As the item in the workqueue is actually invalid, we call
+			// Forget here else we'd go into a loop of attempting to
+			// process a work item that is invalid.
+			c.workqueue.Forget(obj)
+			utilruntime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
+			return nil
+		}
+		// Run the syncHandler, passing it the namespace/name string of the
+		// Foo resource to be synced.
+		if err := c.syncHandler(key); err != nil {
+			// Put the item back on the workqueue to handle any transient errors.
+			c.workqueue.AddRateLimited(key)
+			return fmt.Errorf("error syncing '%s': %s, requeuing", key, err.Error())
+		} else {
+			// Finally, if no error occurs we Forget this item so it does not
+			// get queued again until another change happens.
+			c.workqueue.Forget(obj)
+		}
+		klog.Infof("Successfully synced '%s'", key)
+		return nil
+	}(obj)
+
+	if err != nil {
+		utilruntime.HandleError(err)
+		return true
+	}
+
+	return true
+}
+
+// syncHandler compares the actual state with the desired, and attempts to
+// converge the two. It then updates the Status block of the Foo resource
+// with the current status of the resource.
+func (c *Controller) syncHandler(key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return fmt.Errorf("invalid resource key: %s", key)
+	}
+
+	// 取得 ConfigMap
+	configMap, err := c.configMapLister.ConfigMaps(namespace).Get(name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// ConfigMap 被刪除，需要額外刪掉 DaemonSet
+			klog.Infof("ConfigMap %s deleted", key)
+			err := c.kubeclientset.AppsV1().DaemonSets(namespace).Delete(context.TODO(), daemonSetName, metav1.DeleteOptions{})
+			if err != nil {
+				if errors.IsNotFound(err) {
+					klog.Infof("DaemonSet %s already deleted", daemonSetName)
+					return nil
+				}
+				return fmt.Errorf("Failed to delete DaemonSet %s: %v", daemonSetName, err)
+			}
+
+			klog.Infof("DaemonSet %s deleted due to ConfigMap %s removal", daemonSetName, key)
+			return nil
+		}
+		return err
+	}
+
+	// 解析 ConfigMap
+	var dscpConfig DscpConfig
+	yamlData := configMap.Data[configMapYamlData]
+	err = yaml.Unmarshal([]byte(yamlData), &dscpConfig)
+	if err != nil {
+		return fmt.Errorf("Unmarshal DSCP config error: %v", err)
+	}
+
+	// ConfigMap 存在，準備建立或更新對應 DaemonSet
+	timestamp := time.Now().Format(time.RFC3339)
+	_, err = c.daemonSetLister.DaemonSets(namespace).Get(daemonSetName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// DaemonSet 尚未建立，創建它
+			newDS := newDaemonSetFromConfigMap(c.kubeclientset, dscpConfig, daemonSetName, timestamp)
+			_, err := c.kubeclientset.AppsV1().DaemonSets(namespace).Create(context.TODO(), newDS, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("Failed to create DaemonSet %s: %v", daemonSetName, err)
+			}
+			// 更新 MARS DSCP
+			err = sendMarsAPI(dscpConfig)
+			if err != nil {
+				return err
+			}
+			klog.Infof("Created DaemonSet %s for ConfigMap %s", daemonSetName, key)
+			return nil
+		}
+		return fmt.Errorf("Failed to get DaemonSet %s: %v", daemonSetName, err)
+	}
+
+	// DaemonSet 存在，觸發滾動更新以套用 ConfigMap 最新內容
+	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"create-time":"%s"}}}`, timestamp))
+	_, err = c.kubeclientset.AppsV1().DaemonSets(namespace).Patch(context.TODO(), daemonSetName, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("Failed to patch DaemonSet %s: %v", name, err)
+	}
+	klog.Infof("Patched DaemonSet %s to trigger rolling update due to ConfigMap change", name)
+
+	// 更新 DaemonSet 中 DSCP Pod 的 iptables
+	dscpIpMap := convertDscpIpMapFromConfigMap(c.kubeclientset, dscpConfig)
+	executeCommandInPod(c.kubeclientset, generateIptablesDscpCommand(dscpIpMap, true))
+
+	// 更新 MARS DSCP
+	err = sendMarsAPI(dscpConfig)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getMarsCookie(dscpConfig DscpConfig) (*string, error) {
+    data := map[string]string{
+        "user_name": dscpConfig.MARS["username"],
+        "password": dscpConfig.MARS["password"],
+    }
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("MARS cookie json encoding failed: %v", err)
+    }
+
+	marsUrl := dscpConfig.MARS["api"] + "/mars/useraccount/v1/swagger-login"
+
+	// 建立 POST 請求
+    req, err := http.NewRequest("POST", marsUrl, bytes.NewBuffer(jsonData))
+    if err != nil {
+		return nil, fmt.Errorf("Failed to create MARS cookie request: %v", err)
+    }
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	// 建立 http client 並發送請求
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    if err != nil {
+		return nil, fmt.Errorf("Failed to send MARS cookie request: %v", err)
+    }
+    defer resp.Body.Close()
+
+	sessionID := resp.Header.Get("MARS_G_SESSION_ID")
+    klog.V(4).Infof("MARS session ID: %s\n", sessionID)
+
+	return &sessionID, nil
+}
+
+func sendMarsAPI(dscpConfig DscpConfig) error {
+	var (
+		marsCookie *string
+		err error
+	)
+	marsCookie, err = getMarsCookie(dscpConfig)
+	if err != nil {
+		return fmt.Errorf("Get MARS cookie error: %v", err)
+	}
+	for queue, dscps := range dscpConfig.QueueDscpMap {
+		parts := strings.Split(queue, "-")
+		if len(parts) < 2 {
+			return fmt.Errorf("Format error, missing '-'")
+		}
+
+		queueNum, err := strconv.Atoi(parts[len(parts)-1])
+		if err != nil {
+			return fmt.Errorf("Failed to convert number:", err)
+		}
+
+		// 要傳送的 JSON 資料
+		data := map[string]interface{}{
+			"queue": queueNum,
+			"dscp": dscps,
+		}
+		jsonData, err := json.Marshal(data)
+		if err != nil {
+			return fmt.Errorf("MARS DSCP json encoding failed: %v", err)
+		}
+
+		marsUrl := dscpConfig.MARS["api"] + "/mars/qos/cos/v1"
+
+		// 建立請求
+		req, err := http.NewRequest("PUT", marsUrl, bytes.NewBuffer(jsonData))
+		if err != nil {
+			return fmt.Errorf("Failed to create MARS DSCP request: %v", err)
+		}
+
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+
+		// 設定 Cookie
+		req.AddCookie(&http.Cookie{
+			Name: "marsGSessionId",
+			Value: *marsCookie,
+		})
+
+		// 發送請求
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			return fmt.Errorf("Failed to send MARS DSCP request: %v", err)
+		}
+		defer resp.Body.Close()
+	}
+	return nil
+}
+
+func convertDscpIpMapFromConfigMap(clientset kubernetes.Interface, dscpConfig DscpConfig) map[string][]string {
+	dscpIpMap := make(map[string][]string)
+	for _, ns := range dscpConfig.NamespaceDscpMap {
+		klog.V(4).Infof("Namespace: %s, DSCP: %s", ns.Name, ns.DSCP)
+		dscpIpMap[ns.DSCP] = make([]string, 0)
+		pods, err := clientset.CoreV1().Pods(ns.Name).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("Error fetching Pods in namespace %s: %s", ns.Name, err.Error()))
+			continue
+		}
+
+		// 列出每個 Pod 的 IP
+		for _, pod := range pods.Items {
+			// 檢查 Pod 是否有 IP 地址
+			if !pod.Spec.HostNetwork && pod.Status.PodIP != "" {
+				dscpIpMap[ns.DSCP] = append(dscpIpMap[ns.DSCP], pod.Status.PodIP + "/32")
+				klog.V(4).Infof("Pod Name: %s, IP: %s\n", pod.Name, pod.Status.PodIP)
+			}
+		}
+	}
+	return dscpIpMap
+}
+
+func generateIptablesDscpCommand(dscpIpMap map[string][]string, updateFlag bool) []string {
+	commands := make([]string, 0)
+	commands = append(commands, "iptables -t mangle -F")
+	for dscp, podIps := range dscpIpMap {
+	    for _, ip := range podIps {
+	        markPacket := fmt.Sprintf("iptables -t mangle -A POSTROUTING -d %s -j MARK --set-mark %s", ip, dscp)
+            commands = append(commands, markPacket)
+	    }
+	    setDscp := fmt.Sprintf("iptables -t mangle -A POSTROUTING -m mark --mark %s -j DSCP --set-dscp %s", dscp, dscp)
+	    commands = append(commands, setDscp)
+	}
+	
+	if !updateFlag {
+		commands = append(commands, "sleep infinity")
+		fullCommandStr := strings.Join(commands, " && ")
+		return []string{fullCommandStr}
+	} else {
+		fullCommandStr := strings.Join(commands, " && ")
+    	return []string{"sh", "-c", fullCommandStr}
+	}
+}
+
+func executeCommandInPod(clientset kubernetes.Interface, command []string) {
+	kubeConfig, _ := clientset.CoreV1().ConfigMaps("kubesphere-controls-system").Get(context.TODO(), "kubeconfig-admin", metav1.GetOptions{})
+	kubeConfigData := kubeConfig.Data["config"]
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig([]byte(kubeConfigData))
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+
+	setSelector := labels.SelectorFromSet(labels.Set(map[string]string{"app": appName, "daemonset-owner": daemonSetName}))
+	pods, err := clientset.CoreV1().Pods(configNamespace).List(
+		context.TODO(),
+		metav1.ListOptions{
+			LabelSelector: setSelector.String(),
+		},
+	)
+
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	
+	// DSCP DaemonSet 底下所有 Pod 都需要進行 exec
+	for _, pod := range pods.Items {
+		req := clientset.CoreV1().RESTClient().Post().
+			Resource("pods").
+			Name(pod.Name).
+			Namespace(pod.Namespace).
+			SubResource("exec")
+		req.VersionedParams(&corev1.PodExecOptions{
+			Command:   command,
+			Stderr:    true,
+		}, scheme.ParameterCodec)
+
+		// 建立執行器
+		exec, err := remotecommand.NewSPDYExecutor(restConfig, "POST", req.URL())
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("Error creating SPDY executor: %v", err))
+			return
+		}
+
+		// 執行命令
+		var stderr bytes.Buffer
+		err = exec.Stream(remotecommand.StreamOptions{
+			Stderr: &stderr,
+		})
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("Error executing command: %v", err))
+		}
+		if stderr.Len() != 0 {
+			utilruntime.HandleError(fmt.Errorf(string(stderr.Bytes())))
+		}
+	}
+}
+
+func newDaemonSetFromConfigMap(clientset kubernetes.Interface, dscpConfig DscpConfig, daemonSetName string, timestamp string) *appsv1.DaemonSet {
+	dscpIpMap := convertDscpIpMapFromConfigMap(clientset, dscpConfig)
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      daemonSetName,
+			Namespace: configNamespace,
+			Labels: map[string]string{
+				"created-by": controllerName,
+				"configmap-owner": configName,
+			},
+			Annotations: map[string]string{
+				"create-time": timestamp,
+			},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": appName},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": appName,
+						"daemonset-owner": daemonSetName,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "dscp-container",
+							Image: "iptables",
+							Command: []string{"sh", "-c"},
+							Args: generateIptablesDscpCommand(dscpIpMap, false),
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "config-volume",
+									MountPath: "/etc/config", // 配置掛載到 Pod 中的目錄
+								},
+							},
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							SecurityContext: &corev1.SecurityContext{
+								Capabilities: &corev1.Capabilities{
+									Add:  []corev1.Capability{"NET_ADMIN"},
+									Drop: []corev1.Capability{"KILL"},
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "config-volume",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: configName,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *Controller) enqueueConfigMap(obj interface{}) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	// 非指定的 ConfigMap (namespace/name) 將不會進入 syncHandler 進行邏輯處理
+	configMapKey := configNamespace + "/" + configName
+	if key != configMapKey {
+		klog.V(4).Infof("Non-DSCP ConfigMap: %s", key)
+		return
+	}
+	c.workqueue.Add(key)
+}
+
+func (c *Controller) enqueueDaemonSet(obj interface{}) {
+	daemonSet, ok := obj.(*appsv1.DaemonSet)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("error decoding daemon set, invalid type"))
+			return
+		}
+		daemonSet, ok = tombstone.Obj.(*appsv1.DaemonSet)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("error decoding daemon set tombstone, invalid type"))
+			return
+		}
+		klog.V(4).Infof("Recovered deleted daemon set '%s' from tombstone", daemonSet.GetName())
+	}
+
+	// 確認這是 DSCP DaemonSet
+	if daemonSet.Name != "k8s-dscp" || daemonSet.Namespace != configNamespace {
+		return
+	}
+
+	// 檢查 ConfigMap 是否還存在
+	_, err := c.configMapLister.ConfigMaps(configNamespace).Get(configName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			klog.Infof("ConfigMap still not found, skipping recreate of DaemonSet")
+			return
+		}
+		utilruntime.HandleError(fmt.Errorf("Failed to get ConfigMap: %v", err))
+		return
+	}
+
+	// ConfigMap 還存在，將其加入 workqueue
+	configMapKey := configNamespace + "/" + configName
+	c.workqueue.Add(configMapKey)
+}
+
+func (c *Controller) handlePodUpdate(oldObj, newObj interface{}) {
+    oldPod := oldObj.(*corev1.Pod)
+	newPod := newObj.(*corev1.Pod)
+
+	// 判斷是否從沒有 IP 變成有 IP
+	if oldPod.Status.PodIP == "" && newPod.Status.PodIP != "" {
+		execSinglePodIptables(c, newPod, false)
+	}
+}
+
+func (c *Controller) handlePodDelete(obj interface{}) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("error decoding pod, invalid type"))
+			return
+		}
+		pod, ok = tombstone.Obj.(*corev1.Pod)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("error decoding pod tombstone, invalid type"))
+			return
+		}
+		klog.V(4).Infof("Recovered deleted pod '%s' from tombstone", pod.GetName())
+	}
+
+	execSinglePodIptables(c, pod, true)
+}
+
+func execSinglePodIptables(c *Controller, pod *corev1.Pod, isPodDelete bool) {
+    val, ok := pod.Labels["app"]
+	checkAppLabel := ok && val == appName
+
+	val, ok = pod.Labels["daemonset-owner"]
+	checkOwnerLabel := ok && val == daemonSetName
+
+	// 如果是 DSCP Pod 的 Event 則略過
+	isDscpPod := checkAppLabel && checkOwnerLabel
+	if isDscpPod {
+		klog.V(4).Infof("Skip DSCP pod event: %s/%s", pod.Namespace, pod.Name)
+		return
+	}
+
+	// 取得 ConfigMap
+	configMap, err := c.configMapLister.ConfigMaps(configNamespace).Get(configName)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("Failed to get ConfigMap: %v", err))
+		return
+	}
+
+	// 解析 ConfigMap
+	var dscpConfig DscpConfig
+	yamlData := configMap.Data[configMapYamlData]
+	err = yaml.Unmarshal([]byte(yamlData), &dscpConfig)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("execSinglePodIptables function error: %v", err))
+		return
+	}
+
+	param := "-A"
+	describe := "Add new pod IP in iptables"
+	if isPodDelete {
+		param = "-D"
+		describe = "Delete pod IP in iptables"
+	}
+	
+	for _, ns := range dscpConfig.NamespaceDscpMap {
+		if ns.Name == pod.Namespace {
+			// 檢查 Pod 是否有 IP 地址
+			if !pod.Spec.HostNetwork && pod.Status.PodIP != "" {
+				iptablesPodIp := pod.Status.PodIP + "/32"
+				command := fmt.Sprintf("iptables -t mangle %s POSTROUTING -d %s -j MARK --set-mark %s", param, iptablesPodIp, ns.DSCP)
+				klog.Infof("%s: %s/%s (%s)", describe, pod.Namespace, pod.Name, iptablesPodIp)
+				executeCommandInPod(c.kubeclientset, strings.Fields(command))
+				return
+			}
+			return
+		}
+	}
+}

--- a/pkg/controller/dscp/dscp_controller.go
+++ b/pkg/controller/dscp/dscp_controller.go
@@ -1,3 +1,7 @@
+/*
+ Copyright(c) 2025-present Accton. All rights reserved. www.accton.com.tw
+ */
+
 package dscp
 
 import (
@@ -61,7 +65,6 @@ type DscpConfig struct {
 	NamespaceDscpMap []NamespaceDscp     `yaml:"namespace_dscp_map"`
 }
 
-// Controller is the controller implementation for Foo resources
 type Controller struct {
 	// kubeclientset is a standard kubernetes clientset
 	kubeclientset kubernetes.Interface
@@ -270,6 +273,8 @@ func (c *Controller) syncHandler(key string) error {
 		if errors.IsNotFound(err) {
 			// DSCP ConfigMap is deleted, and DaemonSet needs to be deleted
 			klog.Infof("ConfigMap %s deleted", key)
+			command := fmt.Sprintf("iptables -t mangle -F POSTROUTING")
+			executeCommandInPod(c.kubeclientset, strings.Fields(command))
 			err := c.kubeclientset.AppsV1().DaemonSets(namespace).Delete(context.TODO(), daemonSetName, metav1.DeleteOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {
@@ -384,7 +389,7 @@ func sendMarsAPI(dscpConfig DscpConfig) error {
 
 		queueNum, err := strconv.Atoi(parts[len(parts)-1])
 		if err != nil {
-			return fmt.Errorf("Failed to convert number:", err)
+			return fmt.Errorf("Failed to convert number: %v", err)
 		}
 
 		// DSCP json data to be sent
@@ -450,7 +455,7 @@ func convertDscpIpMapFromConfigMap(clientset kubernetes.Interface, dscpConfig Ds
 
 func generateIptablesDscpCommand(dscpIpMap map[string][]string, updateFlag bool) []string {
 	commands := make([]string, 0)
-	commands = append(commands, "iptables -t mangle -F")
+	commands = append(commands, "iptables -t mangle -F POSTROUTING")
 	for dscp, podIps := range dscpIpMap {
 	    for _, ip := range podIps {
 	        markPacket := fmt.Sprintf("iptables -t mangle -A POSTROUTING -d %s -j MARK --set-mark %s", ip, dscp)
@@ -553,6 +558,7 @@ func newDaemonSetFromConfigMap(clientset kubernetes.Interface, dscpConfig DscpCo
 					},
 				},
 				Spec: corev1.PodSpec{
+					HostNetwork: true,
 					Containers: []corev1.Container{
 						{
 							Name:  "dscp-container",

--- a/pkg/controller/dscp/dscp_controller.go
+++ b/pkg/controller/dscp/dscp_controller.go
@@ -262,11 +262,11 @@ func (c *Controller) syncHandler(key string) error {
 		return fmt.Errorf("invalid resource key: %s", key)
 	}
 
-	// 取得 ConfigMap
+	// Get DSCP ConfigMap
 	configMap, err := c.configMapLister.ConfigMaps(namespace).Get(name)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			// ConfigMap 被刪除，需要額外刪掉 DaemonSet
+			// DSCP ConfigMap is deleted, and DaemonSet needs to be deleted
 			klog.Infof("ConfigMap %s deleted", key)
 			err := c.kubeclientset.AppsV1().DaemonSets(namespace).Delete(context.TODO(), daemonSetName, metav1.DeleteOptions{})
 			if err != nil {
@@ -283,7 +283,7 @@ func (c *Controller) syncHandler(key string) error {
 		return err
 	}
 
-	// 解析 ConfigMap
+	// Parsing DSCP ConfigMap
 	var dscpConfig DscpConfig
 	yamlData := configMap.Data[configMapYamlData]
 	err = yaml.Unmarshal([]byte(yamlData), &dscpConfig)
@@ -291,21 +291,22 @@ func (c *Controller) syncHandler(key string) error {
 		return fmt.Errorf("Unmarshal DSCP config error: %v", err)
 	}
 
-	// ConfigMap 存在，準備建立或更新對應 DaemonSet
+	// Update MARS DSCP
+	err = sendMarsAPI(dscpConfig)
+	if err != nil {
+		return err
+	}
+
+	// DSCP ConfigMap exists and is ready to create or update the corresponding DaemonSet
 	timestamp := time.Now().Format(time.RFC3339)
 	_, err = c.daemonSetLister.DaemonSets(namespace).Get(daemonSetName)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			// DaemonSet 尚未建立，創建它
+			// DaemonSet has not been created yet, create it
 			newDS := newDaemonSetFromConfigMap(c.kubeclientset, dscpConfig, daemonSetName, timestamp)
 			_, err := c.kubeclientset.AppsV1().DaemonSets(namespace).Create(context.TODO(), newDS, metav1.CreateOptions{})
 			if err != nil {
 				return fmt.Errorf("Failed to create DaemonSet %s: %v", daemonSetName, err)
-			}
-			// 更新 MARS DSCP
-			err = sendMarsAPI(dscpConfig)
-			if err != nil {
-				return err
 			}
 			klog.Infof("Created DaemonSet %s for ConfigMap %s", daemonSetName, key)
 			return nil
@@ -313,7 +314,7 @@ func (c *Controller) syncHandler(key string) error {
 		return fmt.Errorf("Failed to get DaemonSet %s: %v", daemonSetName, err)
 	}
 
-	// DaemonSet 存在，觸發滾動更新以套用 ConfigMap 最新內容
+	// DaemonSet exists, triggering a rolling update to apply the latest content of DSCP ConfigMap
 	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"create-time":"%s"}}}`, timestamp))
 	_, err = c.kubeclientset.AppsV1().DaemonSets(namespace).Patch(context.TODO(), daemonSetName, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
 	if err != nil {
@@ -321,15 +322,9 @@ func (c *Controller) syncHandler(key string) error {
 	}
 	klog.Infof("Patched DaemonSet %s to trigger rolling update due to ConfigMap change", name)
 
-	// 更新 DaemonSet 中 DSCP Pod 的 iptables
+	// Update iptables for DSCP Pod in DaemonSet
 	dscpIpMap := convertDscpIpMapFromConfigMap(c.kubeclientset, dscpConfig)
 	executeCommandInPod(c.kubeclientset, generateIptablesDscpCommand(dscpIpMap, true))
-
-	// 更新 MARS DSCP
-	err = sendMarsAPI(dscpConfig)
-	if err != nil {
-		return err
-	}
 
 	return nil
 }
@@ -347,7 +342,7 @@ func getMarsCookie(dscpConfig DscpConfig) (*string, error) {
 
 	marsUrl := dscpConfig.MARS["api"] + "/mars/useraccount/v1/swagger-login"
 
-	// 建立 POST 請求
+	// Building a POST request
     req, err := http.NewRequest("POST", marsUrl, bytes.NewBuffer(jsonData))
     if err != nil {
 		return nil, fmt.Errorf("Failed to create MARS cookie request: %v", err)
@@ -356,7 +351,7 @@ func getMarsCookie(dscpConfig DscpConfig) (*string, error) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
-	// 建立 http client 並發送請求
+	// Create an http client and send a request
     client := &http.Client{}
     resp, err := client.Do(req)
     if err != nil {
@@ -390,7 +385,7 @@ func sendMarsAPI(dscpConfig DscpConfig) error {
 			return fmt.Errorf("Failed to convert number:", err)
 		}
 
-		// 要傳送的 JSON 資料
+		// DSCP json data to be sent
 		data := map[string]interface{}{
 			"queue": queueNum,
 			"dscp": dscps,
@@ -402,7 +397,7 @@ func sendMarsAPI(dscpConfig DscpConfig) error {
 
 		marsUrl := dscpConfig.MARS["api"] + "/mars/qos/cos/v1"
 
-		// 建立請求
+		// Building a PUT request
 		req, err := http.NewRequest("PUT", marsUrl, bytes.NewBuffer(jsonData))
 		if err != nil {
 			return fmt.Errorf("Failed to create MARS DSCP request: %v", err)
@@ -411,13 +406,13 @@ func sendMarsAPI(dscpConfig DscpConfig) error {
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "application/json")
 
-		// 設定 Cookie
+		// Setting MARS cookies
 		req.AddCookie(&http.Cookie{
 			Name: "marsGSessionId",
 			Value: *marsCookie,
 		})
 
-		// 發送請求
+		// Send Request
 		client := &http.Client{}
 		resp, err := client.Do(req)
 		if err != nil {
@@ -439,9 +434,9 @@ func convertDscpIpMapFromConfigMap(clientset kubernetes.Interface, dscpConfig Ds
 			continue
 		}
 
-		// 列出每個 Pod 的 IP
+		// List the IP of each Pod
 		for _, pod := range pods.Items {
-			// 檢查 Pod 是否有 IP 地址
+			// Check if the Pod has an IP address
 			if !pod.Spec.HostNetwork && pod.Status.PodIP != "" {
 				dscpIpMap[ns.DSCP] = append(dscpIpMap[ns.DSCP], pod.Status.PodIP + "/32")
 				klog.V(4).Infof("Pod Name: %s, IP: %s\n", pod.Name, pod.Status.PodIP)
@@ -463,6 +458,8 @@ func generateIptablesDscpCommand(dscpIpMap map[string][]string, updateFlag bool)
 	    commands = append(commands, setDscp)
 	}
 	
+	// "sleep infinity" is added to prevent DaemonSet from continuously re-establishing Pods
+	// because the Pod status changes to "complete" after the Pod is created and iptables commands are executed.
 	if !updateFlag {
 		commands = append(commands, "sleep infinity")
 		fullCommandStr := strings.Join(commands, " && ")
@@ -495,7 +492,7 @@ func executeCommandInPod(clientset kubernetes.Interface, command []string) {
 		return
 	}
 	
-	// DSCP DaemonSet 底下所有 Pod 都需要進行 exec
+	// All Pods under the DSCP DaemonSet need to perform exec
 	for _, pod := range pods.Items {
 		req := clientset.CoreV1().RESTClient().Post().
 			Resource("pods").
@@ -507,14 +504,14 @@ func executeCommandInPod(clientset kubernetes.Interface, command []string) {
 			Stderr:    true,
 		}, scheme.ParameterCodec)
 
-		// 建立執行器
+		// Create an executor
 		exec, err := remotecommand.NewSPDYExecutor(restConfig, "POST", req.URL())
 		if err != nil {
 			utilruntime.HandleError(fmt.Errorf("Error creating SPDY executor: %v", err))
 			return
 		}
 
-		// 執行命令
+		// Execute command
 		var stderr bytes.Buffer
 		err = exec.Stream(remotecommand.StreamOptions{
 			Stderr: &stderr,
@@ -560,29 +557,11 @@ func newDaemonSetFromConfigMap(clientset kubernetes.Interface, dscpConfig DscpCo
 							Image: "iptables",
 							Command: []string{"sh", "-c"},
 							Args: generateIptablesDscpCommand(dscpIpMap, false),
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "config-volume",
-									MountPath: "/etc/config", // 配置掛載到 Pod 中的目錄
-								},
-							},
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
 									Add:  []corev1.Capability{"NET_ADMIN"},
 									Drop: []corev1.Capability{"KILL"},
-								},
-							},
-						},
-					},
-					Volumes: []corev1.Volume{
-						{
-							Name: "config-volume",
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: configName,
-									},
 								},
 							},
 						},
@@ -599,7 +578,7 @@ func (c *Controller) enqueueConfigMap(obj interface{}) {
 		utilruntime.HandleError(err)
 		return
 	}
-	// 非指定的 ConfigMap (namespace/name) 將不會進入 syncHandler 進行邏輯處理
+	// Unspecified ConfigMap (namespace/name) will not enter syncHandler for logical processing
 	configMapKey := configNamespace + "/" + configName
 	if key != configMapKey {
 		klog.V(4).Infof("Non-DSCP ConfigMap: %s", key)
@@ -624,12 +603,12 @@ func (c *Controller) enqueueDaemonSet(obj interface{}) {
 		klog.V(4).Infof("Recovered deleted daemon set '%s' from tombstone", daemonSet.GetName())
 	}
 
-	// 確認這是 DSCP DaemonSet
+	// Confirm this is a DSCP DaemonSet
 	if daemonSet.Name != "k8s-dscp" || daemonSet.Namespace != configNamespace {
 		return
 	}
 
-	// 檢查 ConfigMap 是否還存在
+	// Check if the DSCP ConfigMap still exists
 	_, err := c.configMapLister.ConfigMaps(configNamespace).Get(configName)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -640,7 +619,7 @@ func (c *Controller) enqueueDaemonSet(obj interface{}) {
 		return
 	}
 
-	// ConfigMap 還存在，將其加入 workqueue
+	// The DSCP ConfigMap still exists, add it to the workqueue.
 	configMapKey := configNamespace + "/" + configName
 	c.workqueue.Add(configMapKey)
 }
@@ -649,7 +628,7 @@ func (c *Controller) handlePodUpdate(oldObj, newObj interface{}) {
     oldPod := oldObj.(*corev1.Pod)
 	newPod := newObj.(*corev1.Pod)
 
-	// 判斷是否從沒有 IP 變成有 IP
+	// Determine whether the Pod has changed from having no IP to having an IP
 	if oldPod.Status.PodIP == "" && newPod.Status.PodIP != "" {
 		execSinglePodIptables(c, newPod, false)
 	}
@@ -681,21 +660,21 @@ func execSinglePodIptables(c *Controller, pod *corev1.Pod, isPodDelete bool) {
 	val, ok = pod.Labels["daemonset-owner"]
 	checkOwnerLabel := ok && val == daemonSetName
 
-	// 如果是 DSCP Pod 的 Event 則略過
+	// If it is a DSCP Pod event, skip it.
 	isDscpPod := checkAppLabel && checkOwnerLabel
 	if isDscpPod {
 		klog.V(4).Infof("Skip DSCP pod event: %s/%s", pod.Namespace, pod.Name)
 		return
 	}
 
-	// 取得 ConfigMap
+	// Get DSCP ConfigMap
 	configMap, err := c.configMapLister.ConfigMaps(configNamespace).Get(configName)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("Failed to get ConfigMap: %v", err))
 		return
 	}
 
-	// 解析 ConfigMap
+	// Parsing DSCP ConfigMap
 	var dscpConfig DscpConfig
 	yamlData := configMap.Data[configMapYamlData]
 	err = yaml.Unmarshal([]byte(yamlData), &dscpConfig)
@@ -713,11 +692,11 @@ func execSinglePodIptables(c *Controller, pod *corev1.Pod, isPodDelete bool) {
 	
 	for _, ns := range dscpConfig.NamespaceDscpMap {
 		if ns.Name == pod.Namespace {
-			// 檢查 Pod 是否有 IP 地址
+			// Check if the Pod has an IP address
 			if !pod.Spec.HostNetwork && pod.Status.PodIP != "" {
 				iptablesPodIp := pod.Status.PodIP + "/32"
 				command := fmt.Sprintf("iptables -t mangle %s POSTROUTING -d %s -j MARK --set-mark %s", param, iptablesPodIp, ns.DSCP)
-				klog.Infof("%s: %s/%s (%s)", describe, pod.Namespace, pod.Name, iptablesPodIp)
+				klog.Infof("%s: %s/%s (%s)", describe, pod.Namespace, pod.Name, pod.Status.PodIP)
 				executeCommandInPod(c.kubeclientset, strings.Fields(command))
 				return
 			}

--- a/pkg/controller/dscp/dscp_controller.go
+++ b/pkg/controller/dscp/dscp_controller.go
@@ -474,7 +474,7 @@ func generateIptablesDscpCommand(dscpIpMap map[string][]string, updateFlag bool)
 	    setDscp := fmt.Sprintf("iptables -t mangle -A ACCTONDSCP -m mark --mark %s -j DSCP --set-dscp %s", dscp, dscp)
 	    commands = append(commands, setDscp)
 	}
-	
+
 	// "sleep infinity" is added to prevent DaemonSet from continuously re-establishing Pods
 	// because the Pod status changes to "complete" after the Pod is created and iptables commands are executed.
 	if !updateFlag {
@@ -508,7 +508,7 @@ func executeCommandInPod(clientset kubernetes.Interface, command []string) {
 		utilruntime.HandleError(err)
 		return
 	}
-	
+
 	// All Pods under the DSCP DaemonSet need to perform exec
 	for _, pod := range pods.Items {
 		req := clientset.CoreV1().RESTClient().Post().
@@ -688,7 +688,9 @@ func execSinglePodIptables(c *Controller, pod *corev1.Pod, isPodDelete bool) {
 	// Get DSCP ConfigMap
 	configMap, err := c.configMapLister.ConfigMaps(configNamespace).Get(configName)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Failed to get ConfigMap: %v", err))
+		if !errors.IsNotFound(err) {
+			utilruntime.HandleError(fmt.Errorf("Failed to get ConfigMap: %v", err))
+		}
 		return
 	}
 
@@ -701,8 +703,8 @@ func execSinglePodIptables(c *Controller, pod *corev1.Pod, isPodDelete bool) {
 		return
 	}
 
-	// The rules for marking DSCP for Pod IP are prioritized in iptables 
-	// to prevent the packets with Pod IP from not being set with DSCP 
+	// The rules for marking DSCP for Pod IP are prioritized in iptables
+	// to prevent the packets with Pod IP from not being set with DSCP
 	// because the rules have a lower priority than the rules for setting DSCP.
 	param := "-I ACCTONDSCP 1"
 	describe := "Add new pod IP in iptables"
@@ -710,7 +712,7 @@ func execSinglePodIptables(c *Controller, pod *corev1.Pod, isPodDelete bool) {
 		param = "-D ACCTONDSCP"
 		describe = "Delete pod IP in iptables"
 	}
-	
+
 	for _, ns := range dscpConfig.NamespaceDscpMap {
 		if ns.Name == pod.Namespace {
 			// Check if the Pod has an IP address

--- a/pkg/controller/dscp/dscp_controller.go
+++ b/pkg/controller/dscp/dscp_controller.go
@@ -120,7 +120,7 @@ func NewDscpController(
 			newCm := newObj.(*corev1.ConfigMap)
 
 			if reflect.DeepEqual(oldCm.Data, newCm.Data) {
-				return // ConfigMap內容沒變就不進入 enqueue function
+				return // If the ConfigMap content does not change, the enqueue function will not be entered.
 			}
 			controller.enqueueConfigMap(newObj)
 		},

--- a/pkg/controller/dscp/dscp_controller.go
+++ b/pkg/controller/dscp/dscp_controller.go
@@ -273,8 +273,10 @@ func (c *Controller) syncHandler(key string) error {
 		if errors.IsNotFound(err) {
 			// DSCP ConfigMap is deleted, and DaemonSet needs to be deleted
 			klog.Infof("ConfigMap %s deleted", key)
-			command := fmt.Sprintf("iptables -t mangle -F POSTROUTING")
-			executeCommandInPod(c.kubeclientset, strings.Fields(command))
+			// When the DSCP Pod is to be deleted, the rules in the iptables custom chain must be cleared
+			// and the link with the POSTROUTING chain must be removed before the custom chain can be successfully deleted.
+			cmd := fmt.Sprintf("iptables -t mangle -F ACCTONDSCP && iptables -t mangle -D POSTROUTING -j ACCTONDSCP && iptables -t mangle -X ACCTONDSCP")
+			executeCommandInPod(c.kubeclientset, []string{"sh", "-c", cmd})
 			err := c.kubeclientset.AppsV1().DaemonSets(namespace).Delete(context.TODO(), daemonSetName, metav1.DeleteOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {
@@ -455,13 +457,21 @@ func convertDscpIpMapFromConfigMap(clientset kubernetes.Interface, dscpConfig Ds
 
 func generateIptablesDscpCommand(dscpIpMap map[string][]string, updateFlag bool) []string {
 	commands := make([]string, 0)
-	commands = append(commands, "iptables -t mangle -F POSTROUTING")
+	if !updateFlag {
+		// When a Pod is first created, a custom iptable chain must be added and connected to the default POSTROUTING chain.
+		commands = append(commands, "iptables -t mangle -N ACCTONDSCP && iptables -t mangle -A POSTROUTING -j ACCTONDSCP")
+	} else {
+		// When updating iptables due to ConfigMap changes, 
+		// only the rules in the custom chain are deleted in advance to facilitate subsequent rule updates.
+		commands = append(commands, "iptables -t mangle -F ACCTONDSCP")
+	}
+
 	for dscp, podIps := range dscpIpMap {
 	    for _, ip := range podIps {
-	        markPacket := fmt.Sprintf("iptables -t mangle -A POSTROUTING -d %s -j MARK --set-mark %s", ip, dscp)
+	        markPacket := fmt.Sprintf("iptables -t mangle -A ACCTONDSCP -d %s -j MARK --set-mark %s", ip, dscp)
             commands = append(commands, markPacket)
 	    }
-	    setDscp := fmt.Sprintf("iptables -t mangle -A POSTROUTING -m mark --mark %s -j DSCP --set-dscp %s", dscp, dscp)
+	    setDscp := fmt.Sprintf("iptables -t mangle -A ACCTONDSCP -m mark --mark %s -j DSCP --set-dscp %s", dscp, dscp)
 	    commands = append(commands, setDscp)
 	}
 	
@@ -691,10 +701,13 @@ func execSinglePodIptables(c *Controller, pod *corev1.Pod, isPodDelete bool) {
 		return
 	}
 
-	param := "-A"
+	// The rules for marking DSCP for Pod IP are prioritized in iptables 
+	// to prevent the packets with Pod IP from not being set with DSCP 
+	// because the rules have a lower priority than the rules for setting DSCP.
+	param := "-I ACCTONDSCP 1"
 	describe := "Add new pod IP in iptables"
 	if isPodDelete {
-		param = "-D"
+		param = "-D ACCTONDSCP"
 		describe = "Delete pod IP in iptables"
 	}
 	
@@ -703,7 +716,7 @@ func execSinglePodIptables(c *Controller, pod *corev1.Pod, isPodDelete bool) {
 			// Check if the Pod has an IP address
 			if !pod.Spec.HostNetwork && pod.Status.PodIP != "" {
 				iptablesPodIp := pod.Status.PodIP + "/32"
-				command := fmt.Sprintf("iptables -t mangle %s POSTROUTING -d %s -j MARK --set-mark %s", param, iptablesPodIp, ns.DSCP)
+				command := fmt.Sprintf("iptables -t mangle %s -d %s -j MARK --set-mark %s", param, iptablesPodIp, ns.DSCP)
 				klog.Infof("%s: %s/%s (%s)", describe, pod.Namespace, pod.Name, pod.Status.PodIP)
 				executeCommandInPod(c.kubeclientset, strings.Fields(command))
 				return


### PR DESCRIPTION
### The content of this PR is as follows:

* The controller is triggered according to the DSCP ConfigMap content. The format is as follows:
```yaml
cni: "calico" # "calico" or "ovn"
container_image: <image name>
mars: 
  api: http://<MARS server IP>:<port>
  username: <username>
  password: <password>
queue_dscp_map:
  queue-0: [0,1,2,3,4,5,6,7]
  queue-1: [8,9,10,11,12,13,14,15]
  queue-2: [16,17,18,19,20,21,22,23]
  queue-3: [24,25,26,27,28,29,30,31]
  queue-4: [32,33,34,35,36,37,38,39]
  queue-5: [40,41,42,43,44,45,46,47]
  queue-6: [48,49,50,51,52,53,54,55]
  queue-7: [56,57,58,59,60,61,62,63]
namespace_dscp_map:
  - name: default
    dscp: 8
  - name: <other namespace>
    dscp: 16
```
* After the DSCP ConfigMap is created, a DaemonSet will be automatically created and the DSCP Pod will be started. The Pod will use iptables to issue commands based on the value of the "**namespace_dscp_map**" field in the ConfigMap.
* According to the value of the "**queue_dscp_map**" field in ConfigMap, the controller will send a DSCP request to MARS to change the queue.