### PR TITLE
Feature/elvis namespace schedule and expire

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
 	github.com/kubesphere/pvc-autoresizer v0.1.1
 	github.com/kubesphere/sonargo v0.0.2
-	github.com/kubesphere/storageclass-accessor v0.2.0
+	github.com/kubesphere/storageclass-accessor v0.2.2
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
@@ -555,7 +555,7 @@ replace (
 	github.com/kubernetes-csi/external-snapshotter/v2 => github.com/kubernetes-csi/external-snapshotter/v2 v2.1.1
 	github.com/kubesphere/pvc-autoresizer => github.com/kubesphere/pvc-autoresizer v0.1.1
 	github.com/kubesphere/sonargo => github.com/kubesphere/sonargo v0.0.2
-	github.com/kubesphere/storageclass-accessor => github.com/kubesphere/storageclass-accessor v0.2.0
+	github.com/kubesphere/storageclass-accessor => github.com/kubesphere/storageclass-accessor v0.2.2
 	github.com/kylelemons/go-gypsy => github.com/kylelemons/go-gypsy v0.0.0-20160905020020-08cad365cd28
 	github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20160406211939-eadb3ce320cb
 	github.com/lann/builder => github.com/lann/builder v0.0.0-20180802200727-47ae307949d0

--- a/go.sum
+++ b/go.sum
@@ -549,8 +549,8 @@ github.com/kubesphere/pvc-autoresizer v0.1.1 h1:Q0VrvLfTiE1f38EvmFpJdBevwN21X7Br
 github.com/kubesphere/pvc-autoresizer v0.1.1/go.mod h1:88qz9L1Ov2bvw7L/i5mUT8g5DvBwRCZ60JA2d1WLgB0=
 github.com/kubesphere/sonargo v0.0.2 h1:hsSRE3sv3mkPcUAeSABdp7rtfcNW2zzeHXzFa01CTkU=
 github.com/kubesphere/sonargo v0.0.2/go.mod h1:ww8n9ANlDXhX5PBZ18iaRnCgEkXN0GMml3/KZXOZ11w=
-github.com/kubesphere/storageclass-accessor v0.2.0 h1:rnzKafhneo8160dh6REm3z1yAEaQWz1x/Lwi3QFVLWE=
-github.com/kubesphere/storageclass-accessor v0.2.0/go.mod h1:jqZ3tCiw09yOiPkZ3rDmf6QIpbZJx55McnyRaS0ayCY=
+github.com/kubesphere/storageclass-accessor v0.2.2 h1:FzKRQwwOYYwccZyG6z3ENFiONWAQ03d6SGs7H9N6gfI=
+github.com/kubesphere/storageclass-accessor v0.2.2/go.mod h1:jqZ3tCiw09yOiPkZ3rDmf6QIpbZJx55McnyRaS0ayCY=
 github.com/kylelemons/go-gypsy v0.0.0-20160905020020-08cad365cd28/go.mod h1:T/T7jsxVqf9k/zYOqbgNAsANsjxTd1Yq3htjDhQ1H0c=
 github.com/kylelemons/godebug v0.0.0-20160406211939-eadb3ce320cb/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=

--- a/pkg/models/tenant/tenant.go
+++ b/pkg/models/tenant/tenant.go
@@ -81,6 +81,7 @@ import (
 const (
 	orphanFinalizer = "orphan.finalizers.kubesphere.io"
 	namespaceStartTime                = "ecpaas.io/start-time"
+	namespaceExpireTime               = "ecpaas.io/expire-time"
 	namespaceControllerNamespace      = "ns-expire-controller-system"
 	namespaceControllerServiceaccount = "ns-expire-controller-controller-manager"
 )
@@ -423,6 +424,7 @@ func (t *tenantOperator) ListNamespaces(user user.Info, workspace string, queryP
 // but if the host cluster is not authorized to workspace, there will be no workspace in host cluster.
 func (t *tenantOperator) CreateNamespace(workspace string, namespace *corev1.Namespace) (*corev1.Namespace, error) {
 	labelNamespaceWithWorkspaceName(namespace, workspace)
+	validateTime(namespace)
 	if startTimeString, ok := namespace.Annotations[namespaceStartTime]; ok {
 		// check startTimeString is valid
 		startTime, err := time.Parse(time.RFC3339, startTimeString)
@@ -442,7 +444,6 @@ func (t *tenantOperator) CreateNamespace(workspace string, namespace *corev1.Nam
 			// Use date command to calculate sleep time in seconds, can feed RFC3339 directly
 			sleepCommand := fmt.Sprintf("sleep $(expr $(date -d \"%s\" +%%s) - $(date +%%s))", startTimeString)
 			createCommand := fmt.Sprintf("%s; kubectl apply -f - <<EOF\n%s\nEOF", sleepCommand, string(nsContent))
-			klog.Infof("show createCommand: %s", createCommand)
 
 			zero := int32(0)
 			job := &batchv1.Job{}
@@ -501,6 +502,21 @@ func isNamespaceControllerInstalled(t *tenantOperator) bool {
 	return true
 }
 
+// Removes empty Start/Expire time in annotations
+func validateTime(namespace *corev1.Namespace) {
+	if startTimeString, ok := namespace.Annotations[namespaceStartTime]; ok {
+		if startTimeString == "" {
+			delete(namespace.Annotations, namespaceStartTime)
+		}
+	}
+
+	if expireTimeString, ok := namespace.Annotations[namespaceExpireTime]; ok {
+		if expireTimeString == "" {
+			delete(namespace.Annotations, namespaceExpireTime)
+		}
+	}
+}
+
 func (t *tenantOperator) DescribeNamespace(workspace, namespace string) (*corev1.Namespace, error) {
 	obj, err := t.resourceGetter.Get("namespaces", "", namespace)
 	if err != nil {
@@ -538,6 +554,7 @@ func (t *tenantOperator) DeleteNamespace(workspace, namespace string) error {
 }
 
 func (t *tenantOperator) UpdateNamespace(workspace string, namespace *corev1.Namespace) (*corev1.Namespace, error) {
+	validateTime(namespace)
 	_, err := t.DescribeNamespace(workspace, namespace.Name)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -558,6 +575,7 @@ func (t *tenantOperator) UpdateNamespace(workspace string, namespace *corev1.Nam
 }
 
 func (t *tenantOperator) PatchNamespace(workspace string, namespace *corev1.Namespace) (*corev1.Namespace, error) {
+	// This API only modifies annotations, format merge data for PATCH
 	_, err := t.DescribeNamespace(workspace, namespace.Name)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -565,10 +583,21 @@ func (t *tenantOperator) PatchNamespace(workspace string, namespace *corev1.Name
 		}
 		return nil, err
 	}
-	if namespace.Labels != nil {
-		namespace.Labels[tenantv1alpha1.WorkspaceLabel] = workspace
+
+	newAnnotations := make(map[string]interface{}, 0)
+	for key, value := range namespace.Annotations {
+		if value == "" {
+			newAnnotations[key] = nil
+		} else {
+			newAnnotations[key] = value
+		}
 	}
-	data, err := json.Marshal(namespace)
+	patch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": newAnnotations,
+		},
+	}
+	data, err := json.Marshal(patch)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/models/tenant/tenant.go
+++ b/pkg/models/tenant/tenant.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/mitchellh/mapstructure"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -74,9 +75,15 @@ import (
 	"kubesphere.io/kubesphere/pkg/utils/clusterclient"
 	jsonpatchutil "kubesphere.io/kubesphere/pkg/utils/josnpatchutil"
 	"kubesphere.io/kubesphere/pkg/utils/stringutils"
+	yaml "sigs.k8s.io/yaml"
 )
 
-const orphanFinalizer = "orphan.finalizers.kubesphere.io"
+const (
+	orphanFinalizer = "orphan.finalizers.kubesphere.io"
+	namespaceStartTime                = "ecpaas.io/start-time"
+	namespaceControllerNamespace      = "ns-expire-controller-system"
+	namespaceControllerServiceaccount = "ns-expire-controller-controller-manager"
+)
 
 type Interface interface {
 	ListWorkspaces(user user.Info, queryParam *query.Query) (*api.ListResult, error)
@@ -415,7 +422,60 @@ func (t *tenantOperator) ListNamespaces(user user.Info, workspace string, queryP
 // The reason here why don't check the existence of workspace anymore is this function is only executed in host cluster.
 // but if the host cluster is not authorized to workspace, there will be no workspace in host cluster.
 func (t *tenantOperator) CreateNamespace(workspace string, namespace *corev1.Namespace) (*corev1.Namespace, error) {
-	return t.k8sclient.CoreV1().Namespaces().Create(context.Background(), labelNamespaceWithWorkspaceName(namespace, workspace), metav1.CreateOptions{})
+	labelNamespaceWithWorkspaceName(namespace, workspace)
+	if startTimeString, ok := namespace.Annotations[namespaceStartTime]; ok {
+		// check startTimeString is valid
+		startTime, err := time.Parse(time.RFC3339, startTimeString)
+		if err != nil {
+			klog.Error(err)
+			return nil, err
+		}
+		if startTime.After(time.Now()) && isNamespaceControllerInstalled(t) {
+			// Create NS in the future
+			nsContent, err := yaml.Marshal(namespace)
+			if err != nil {
+				klog.Error(err)
+				return nil, err
+			}
+
+			// Calculate sleep time in pod, this command will be executed by /bin/sh
+			// Use date command to calculate sleep time in seconds, can feed RFC3339 directly
+			sleepCommand := fmt.Sprintf("sleep $(expr $(date -d \"%s\" +%%s) - $(date +%%s))", startTimeString)
+			createCommand := fmt.Sprintf("%s; kubectl apply -f - <<EOF\n%s\nEOF", sleepCommand, string(nsContent))
+			klog.Infof("show createCommand: %s", createCommand)
+
+			zero := int32(0)
+			job := &batchv1.Job{}
+			job.Name = "namespace-creator-" + namespace.Name
+			job.Namespace = namespaceControllerNamespace
+			job.Spec = batchv1.JobSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						ServiceAccountName : namespaceControllerServiceaccount,
+						Containers: []corev1.Container{
+							{
+								Name: "namespace-creator",
+								Image: "bitnami/kubectl:1.22.9",
+								Command: []string{
+									"/bin/sh",
+									"-c",
+									createCommand,
+								},
+							},
+						},
+						RestartPolicy: corev1.RestartPolicyNever,
+					},
+				},
+				BackoffLimit: &zero,
+				TTLSecondsAfterFinished: &zero,
+			}
+
+			_, err = t.k8sclient.BatchV1().Jobs(job.Namespace).Create(context.Background(), job, metav1.CreateOptions{})
+			return namespace, err
+		}
+	}
+
+	return t.k8sclient.CoreV1().Namespaces().Create(context.Background(), namespace, metav1.CreateOptions{})
 }
 
 // labelNamespaceWithWorkspaceName adds a kubesphere.io/workspace=[workspaceName] label to namespace which
@@ -428,6 +488,17 @@ func labelNamespaceWithWorkspaceName(namespace *corev1.Namespace, workspaceName 
 	namespace.Labels[tenantv1alpha1.WorkspaceLabel] = workspaceName // label namespace with workspace name
 
 	return namespace
+}
+
+func isNamespaceControllerInstalled(t *tenantOperator) bool {
+	// get serviceaccount and namespace
+	if _, err := t.k8sclient.CoreV1().Namespaces().Get(context.Background(), namespaceControllerNamespace, metav1.GetOptions{}); err != nil {
+		return false
+	}
+	if _, err := t.k8sclient.CoreV1().ServiceAccounts(namespaceControllerNamespace).Get(context.Background(), namespaceControllerServiceaccount, metav1.GetOptions{}); err != nil {
+		return false
+	}
+	return true
 }
 
 func (t *tenantOperator) DescribeNamespace(workspace, namespace string) (*corev1.Namespace, error) {
@@ -447,6 +518,20 @@ func (t *tenantOperator) DescribeNamespace(workspace, namespace string) (*corev1
 func (t *tenantOperator) DeleteNamespace(workspace, namespace string) error {
 	_, err := t.DescribeNamespace(workspace, namespace)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			// Namespace is unstarted yet, check job
+			jobName := "namespace-creator-" + namespace
+			if _, err := t.k8sclient.BatchV1().Jobs(namespaceControllerNamespace).Get(context.Background(), jobName, metav1.GetOptions{}); err == nil {
+				// delete job and pod
+				t.k8sclient.BatchV1().Jobs(namespaceControllerNamespace).Delete(context.Background(), jobName, metav1.DeleteOptions{})
+				zero := int64(0)
+				labelSelector := fmt.Sprintf("job-name in (%s)", jobName)
+				t.k8sclient.CoreV1().Pods(namespaceControllerNamespace).DeleteCollection(context.Background(),
+				metav1.DeleteOptions{GracePeriodSeconds: &zero},
+				metav1.ListOptions{LabelSelector: labelSelector})
+				return nil
+			}
+		}
 		return err
 	}
 	return t.k8sclient.CoreV1().Namespaces().Delete(context.Background(), namespace, *metav1.NewDeleteOptions(0))
@@ -455,6 +540,17 @@ func (t *tenantOperator) DeleteNamespace(workspace, namespace string) error {
 func (t *tenantOperator) UpdateNamespace(workspace string, namespace *corev1.Namespace) (*corev1.Namespace, error) {
 	_, err := t.DescribeNamespace(workspace, namespace.Name)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			// Namespace is unstarted yet, check job
+			jobName := "namespace-creator-" + namespace.Name
+			if _, err := t.k8sclient.BatchV1().Jobs(namespaceControllerNamespace).Get(context.Background(), jobName, metav1.GetOptions{}); err == nil {
+				if err := t.DeleteNamespace(workspace, namespace.Name); err == nil {
+					time.Sleep(500 * time.Millisecond)
+					return t.CreateNamespace(workspace, namespace)
+				}
+				return nil, err
+			}
+		}
 		return nil, err
 	}
 	namespace = labelNamespaceWithWorkspaceName(namespace, workspace)
@@ -464,6 +560,9 @@ func (t *tenantOperator) UpdateNamespace(workspace string, namespace *corev1.Nam
 func (t *tenantOperator) PatchNamespace(workspace string, namespace *corev1.Namespace) (*corev1.Namespace, error) {
 	_, err := t.DescribeNamespace(workspace, namespace.Name)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			return t.UpdateNamespace(workspace, namespace)
+		}
 		return nil, err
 	}
 	if namespace.Labels != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -536,7 +536,7 @@ github.com/kubesphere/pvc-autoresizer/runners
 # github.com/kubesphere/sonargo v0.0.2 => github.com/kubesphere/sonargo v0.0.2
 ## explicit
 github.com/kubesphere/sonargo/sonar
-# github.com/kubesphere/storageclass-accessor v0.2.0 => github.com/kubesphere/storageclass-accessor v0.2.0
+# github.com/kubesphere/storageclass-accessor v0.2.2 => github.com/kubesphere/storageclass-accessor v0.2.2
 ## explicit
 github.com/kubesphere/storageclass-accessor/client/apis/accessor/v1alpha1
 github.com/kubesphere/storageclass-accessor/webhook
@@ -2696,7 +2696,7 @@ sigs.k8s.io/yaml
 # github.com/kubernetes-csi/external-snapshotter/v2 => github.com/kubernetes-csi/external-snapshotter/v2 v2.1.1
 # github.com/kubesphere/pvc-autoresizer => github.com/kubesphere/pvc-autoresizer v0.1.1
 # github.com/kubesphere/sonargo => github.com/kubesphere/sonargo v0.0.2
-# github.com/kubesphere/storageclass-accessor => github.com/kubesphere/storageclass-accessor v0.2.0
+# github.com/kubesphere/storageclass-accessor => github.com/kubesphere/storageclass-accessor v0.2.2
 # github.com/kylelemons/go-gypsy => github.com/kylelemons/go-gypsy v0.0.0-20160905020020-08cad365cd28
 # github.com/kylelemons/godebug => github.com/kylelemons/godebug v0.0.0-20160406211939-eadb3ce320cb
 # github.com/lann/builder => github.com/lann/builder v0.0.0-20180802200727-47ae307949d0


### PR DESCRIPTION
Adds support for setting Start/Expire time to workspace namespace
- fixes bug of deleting namespace will be stopped by PVC issue
- updates namespace APIs to accept start/expire time
- refactors PUT API to really clear annotations instead of just set to ""