### PR TITLE
Fix K8s DSCP controller startup issue

### DIFF
--- a/pkg/controller/dscp/dscp_controller.go
+++ b/pkg/controller/dscp/dscp_controller.go
@@ -285,9 +285,11 @@ func (c *Controller) syncHandler() error {
 	}
 
 	// Update MARS DSCP
-	err = sendMarsAPI(dscpConfig)
-	if err != nil {
-		return err
+	if dscpConfig.MARS != nil {
+		err = sendMarsAPI(dscpConfig)
+		if err != nil {
+			return err
+		}
 	}
 
 	switch dscpConfig.CNI {


### PR DESCRIPTION
### The content of this PR is as follows:

* Fixed an issue where DSCP DaemonSet would not start when there is no MARS configuration.